### PR TITLE
feat: allow for user jit

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -131,7 +131,8 @@ nufftax supports 2D and 3D:
 JIT Compilation
 ---------------
 
-All nufftax functions are JIT-compiled by default. For custom functions:
+nufftax functions are compatible with JAX's JIT compilation. For best performance,
+wrap your functions with ``@jax.jit``:
 
 .. code-block:: python
 
@@ -142,6 +143,14 @@ All nufftax functions are JIT-compiled by default. For custom functions:
 
    # First call compiles, subsequent calls are fast
    power = my_analysis(x, c)
+
+You can also JIT individual NUFFT calls:
+
+.. code-block:: python
+
+   # JIT a single function with static arguments
+   jitted_nufft = jax.jit(nufft1d1, static_argnames=("n_modes", "eps", "isign"))
+   f = jitted_nufft(x, c, n_modes=64, eps=1e-6)
 
 Precision vs Speed
 ------------------

--- a/nufftax/transforms/__init__.py
+++ b/nufftax/transforms/__init__.py
@@ -1,9 +1,10 @@
 """NUFFT transform functions.
 
-All transforms are JIT-compiled by default for 5-11x speedup.
+All transforms are compatible with JAX's JIT compilation. For best performance,
+wrap your functions with ``@jax.jit`` or use ``jax.jit()`` directly.
 """
 
-# Autodiff-enabled transforms (all JIT-compiled)
+# Autodiff-enabled transforms
 from .autodiff import (
     # Helper functions
     compute_position_gradient_1d,

--- a/nufftax/transforms/nufft1.py
+++ b/nufftax/transforms/nufft1.py
@@ -9,8 +9,6 @@ Pipeline: spread -> FFT -> deconvolve
 Reference: FINUFFT finufft_core.cpp
 """
 
-from functools import partial
-
 import jax
 import jax.numpy as jnp
 
@@ -20,7 +18,6 @@ from ..core.spread import spread_1d, spread_2d, spread_3d
 from ..utils.grid import compute_grid_size
 
 
-@partial(jax.jit, static_argnames=("n_modes", "eps", "isign", "upsampfac", "modeord"))
 def nufft1d1(
     x: jax.Array,
     c: jax.Array,
@@ -94,7 +91,6 @@ def nufft1d1(
     return f
 
 
-@partial(jax.jit, static_argnames=("n_modes", "eps", "isign", "upsampfac", "modeord"))
 def nufft2d1(
     x: jax.Array,
     y: jax.Array,
@@ -170,7 +166,6 @@ def nufft2d1(
     return f
 
 
-@partial(jax.jit, static_argnames=("n_modes", "eps", "isign", "upsampfac", "modeord"))
 def nufft3d1(
     x: jax.Array,
     y: jax.Array,

--- a/nufftax/transforms/nufft2.py
+++ b/nufftax/transforms/nufft2.py
@@ -9,8 +9,6 @@ Pipeline: deconvolve -> iFFT -> interpolate
 Reference: FINUFFT finufft_core.cpp
 """
 
-from functools import partial
-
 import jax
 import jax.numpy as jnp
 
@@ -20,7 +18,6 @@ from ..core.spread import interp_1d, interp_2d, interp_3d
 from ..utils.grid import compute_grid_size
 
 
-@partial(jax.jit, static_argnames=("eps", "isign", "upsampfac", "modeord"))
 def nufft1d2(
     x: jax.Array,
     f: jax.Array,
@@ -85,7 +82,6 @@ def nufft1d2(
     return c
 
 
-@partial(jax.jit, static_argnames=("eps", "isign", "upsampfac", "modeord"))
 def nufft2d2(
     x: jax.Array,
     y: jax.Array,
@@ -150,7 +146,6 @@ def nufft2d2(
     return c
 
 
-@partial(jax.jit, static_argnames=("eps", "isign", "upsampfac", "modeord"))
 def nufft3d2(
     x: jax.Array,
     y: jax.Array,

--- a/nufftax/transforms/nufft3.py
+++ b/nufftax/transforms/nufft3.py
@@ -22,8 +22,6 @@ be static). Use `compute_type3_grid_size()` to pre-compute appropriate values.
 Reference: FINUFFT finufft_core.cpp
 """
 
-from functools import partial
-
 import jax
 import jax.numpy as jnp
 
@@ -242,7 +240,6 @@ def _kernel_ft_at_point(k: jax.Array, nspread: int, beta: float, c: float, dtype
     return phi_hat
 
 
-@partial(jax.jit, static_argnames=("eps", "isign", "upsampfac", "n_modes"))
 def nufft1d3(
     x: jax.Array,
     c: jax.Array,
@@ -334,7 +331,6 @@ def nufft1d3(
     return f
 
 
-@partial(jax.jit, static_argnames=("eps", "isign", "upsampfac", "n_modes"))
 def nufft2d3(
     x: jax.Array,
     y: jax.Array,
@@ -430,7 +426,6 @@ def nufft2d3(
     return f
 
 
-@partial(jax.jit, static_argnames=("eps", "isign", "upsampfac", "n_modes"))
 def nufft3d3(
     x: jax.Array,
     y: jax.Array,

--- a/tests/test_adjoint.py
+++ b/tests/test_adjoint.py
@@ -36,7 +36,9 @@ class TestGradientRelationships:
         M, N = 100, 64
         key = jax.random.PRNGKey(42)
         x = jax.random.uniform(key, (M,), minval=-jnp.pi, maxval=jnp.pi)
-        c = jax.random.normal(jax.random.PRNGKey(43), (M,)) + 1j * jax.random.normal(jax.random.PRNGKey(44), (M,))
+        c = jax.random.normal(jax.random.PRNGKey(43), (M,)) + 1j * jax.random.normal(
+            jax.random.PRNGKey(44), (M,)
+        )
         c = c.astype(jnp.complex64)
 
         # Gradient w.r.t. c should be well-defined
@@ -55,7 +57,9 @@ class TestGradientRelationships:
         M, N = 100, 64
         key = jax.random.PRNGKey(42)
         x = jax.random.uniform(key, (M,), minval=-jnp.pi, maxval=jnp.pi)
-        c = jax.random.normal(jax.random.PRNGKey(43), (M,)) + 1j * jax.random.normal(jax.random.PRNGKey(44), (M,))
+        c = jax.random.normal(jax.random.PRNGKey(43), (M,)) + 1j * jax.random.normal(
+            jax.random.PRNGKey(44), (M,)
+        )
         c = c.astype(jnp.complex64)
 
         def loss(x):
@@ -71,7 +75,9 @@ class TestGradientRelationships:
         M, N = 100, 64
         key = jax.random.PRNGKey(42)
         x = jax.random.uniform(key, (M,), minval=-jnp.pi, maxval=jnp.pi)
-        f = jax.random.normal(jax.random.PRNGKey(43), (N,)) + 1j * jax.random.normal(jax.random.PRNGKey(44), (N,))
+        f = jax.random.normal(jax.random.PRNGKey(43), (N,)) + 1j * jax.random.normal(
+            jax.random.PRNGKey(44), (N,)
+        )
         f = f.astype(jnp.complex64)
 
         def loss(f):
@@ -97,7 +103,9 @@ class TestSelfAdjointRoundtrip:
         M, N = 128, 128
         key = jax.random.PRNGKey(42)
         x = jax.random.uniform(key, (M,), minval=-jnp.pi, maxval=jnp.pi)
-        c = jax.random.normal(jax.random.PRNGKey(43), (M,)) + 1j * jax.random.normal(jax.random.PRNGKey(44), (M,))
+        c = jax.random.normal(jax.random.PRNGKey(43), (M,)) + 1j * jax.random.normal(
+            jax.random.PRNGKey(44), (M,)
+        )
         c = c.astype(jnp.complex64)
 
         # Type 1: nonuniform -> uniform
@@ -124,7 +132,9 @@ class TestSelfAdjointRoundtrip:
         key = jax.random.PRNGKey(42)
         x = jax.random.uniform(key, (M,), minval=-jnp.pi, maxval=jnp.pi)
         y = jax.random.uniform(jax.random.PRNGKey(43), (M,), minval=-jnp.pi, maxval=jnp.pi)
-        c = jax.random.normal(jax.random.PRNGKey(44), (M,)) + 1j * jax.random.normal(jax.random.PRNGKey(45), (M,))
+        c = jax.random.normal(jax.random.PRNGKey(44), (M,)) + 1j * jax.random.normal(
+            jax.random.PRNGKey(45), (M,)
+        )
         c = c.astype(jnp.complex64)
 
         F = nufft2d1(x, y, c, (N1, N2), eps=1e-6, isign=1)
@@ -144,7 +154,9 @@ class TestSelfAdjointRoundtrip:
         N = 64
         M = N  # Same number of points as modes
         x = jnp.linspace(-jnp.pi, jnp.pi, M, endpoint=False)
-        c = jax.random.normal(jax.random.PRNGKey(42), (M,)) + 1j * jax.random.normal(jax.random.PRNGKey(43), (M,))
+        c = jax.random.normal(jax.random.PRNGKey(42), (M,)) + 1j * jax.random.normal(
+            jax.random.PRNGKey(43), (M,)
+        )
         c = c.astype(jnp.complex64)
 
         # Type 1 -> Type 2 with uniform spacing should reconstruct well
@@ -165,7 +177,9 @@ class TestGradient2D:
         key = jax.random.PRNGKey(42)
         x = jax.random.uniform(key, (M,), minval=-jnp.pi, maxval=jnp.pi)
         y = jax.random.uniform(jax.random.PRNGKey(43), (M,), minval=-jnp.pi, maxval=jnp.pi)
-        c = jax.random.normal(jax.random.PRNGKey(44), (M,)) + 1j * jax.random.normal(jax.random.PRNGKey(45), (M,))
+        c = jax.random.normal(jax.random.PRNGKey(44), (M,)) + 1j * jax.random.normal(
+            jax.random.PRNGKey(45), (M,)
+        )
         c = c.astype(jnp.complex64)
 
         def loss(c):
@@ -182,7 +196,9 @@ class TestGradient2D:
         key = jax.random.PRNGKey(42)
         x = jax.random.uniform(key, (M,), minval=-jnp.pi, maxval=jnp.pi)
         y = jax.random.uniform(jax.random.PRNGKey(43), (M,), minval=-jnp.pi, maxval=jnp.pi)
-        c = jax.random.normal(jax.random.PRNGKey(44), (M,)) + 1j * jax.random.normal(jax.random.PRNGKey(45), (M,))
+        c = jax.random.normal(jax.random.PRNGKey(44), (M,)) + 1j * jax.random.normal(
+            jax.random.PRNGKey(45), (M,)
+        )
         c = c.astype(jnp.complex64)
 
         def loss(x, y):
@@ -206,7 +222,9 @@ class TestGradient3D:
         x = jax.random.uniform(key, (M,), minval=-jnp.pi, maxval=jnp.pi)
         y = jax.random.uniform(jax.random.PRNGKey(43), (M,), minval=-jnp.pi, maxval=jnp.pi)
         z = jax.random.uniform(jax.random.PRNGKey(44), (M,), minval=-jnp.pi, maxval=jnp.pi)
-        c = jax.random.normal(jax.random.PRNGKey(45), (M,)) + 1j * jax.random.normal(jax.random.PRNGKey(46), (M,))
+        c = jax.random.normal(jax.random.PRNGKey(45), (M,)) + 1j * jax.random.normal(
+            jax.random.PRNGKey(46), (M,)
+        )
         c = c.astype(jnp.complex64)
 
         def loss(c):
@@ -232,7 +250,8 @@ class TestGradientFiniteDifference:
             key = jax.random.PRNGKey(42)
             x = jax.random.uniform(key, (M,), minval=-jnp.pi, maxval=jnp.pi).astype(jnp.float64)
             c = (
-                jax.random.normal(jax.random.PRNGKey(43), (M,)) + 1j * jax.random.normal(jax.random.PRNGKey(44), (M,))
+                jax.random.normal(jax.random.PRNGKey(43), (M,))
+                + 1j * jax.random.normal(jax.random.PRNGKey(44), (M,))
             ).astype(jnp.complex128)
 
             def loss(c):
@@ -267,7 +286,8 @@ class TestGradientFiniteDifference:
             key = jax.random.PRNGKey(42)
             x = jax.random.uniform(key, (M,), minval=-jnp.pi, maxval=jnp.pi).astype(jnp.float64)
             c = (
-                jax.random.normal(jax.random.PRNGKey(43), (M,)) + 1j * jax.random.normal(jax.random.PRNGKey(44), (M,))
+                jax.random.normal(jax.random.PRNGKey(43), (M,))
+                + 1j * jax.random.normal(jax.random.PRNGKey(44), (M,))
             ).astype(jnp.complex128)
 
             def loss(x):
@@ -297,7 +317,8 @@ class TestGradientFiniteDifference:
             key = jax.random.PRNGKey(42)
             x = jax.random.uniform(key, (M,), minval=-jnp.pi, maxval=jnp.pi).astype(jnp.float64)
             f = (
-                jax.random.normal(jax.random.PRNGKey(43), (N,)) + 1j * jax.random.normal(jax.random.PRNGKey(44), (N,))
+                jax.random.normal(jax.random.PRNGKey(43), (N,))
+                + 1j * jax.random.normal(jax.random.PRNGKey(44), (N,))
             ).astype(jnp.complex128)
 
             def loss(f):
@@ -332,7 +353,8 @@ class TestGradientFiniteDifference:
             key = jax.random.PRNGKey(42)
             x = jax.random.uniform(key, (M,), minval=-jnp.pi, maxval=jnp.pi).astype(jnp.float64)
             f = (
-                jax.random.normal(jax.random.PRNGKey(43), (N,)) + 1j * jax.random.normal(jax.random.PRNGKey(44), (N,))
+                jax.random.normal(jax.random.PRNGKey(43), (N,))
+                + 1j * jax.random.normal(jax.random.PRNGKey(44), (N,))
             ).astype(jnp.complex128)
 
             def loss(x):
@@ -361,9 +383,12 @@ class TestGradientFiniteDifference:
             M, N1, N2 = 15, 8, 10
             key = jax.random.PRNGKey(42)
             x = jax.random.uniform(key, (M,), minval=-jnp.pi, maxval=jnp.pi).astype(jnp.float64)
-            y = jax.random.uniform(jax.random.PRNGKey(43), (M,), minval=-jnp.pi, maxval=jnp.pi).astype(jnp.float64)
+            y = jax.random.uniform(
+                jax.random.PRNGKey(43), (M,), minval=-jnp.pi, maxval=jnp.pi
+            ).astype(jnp.float64)
             c = (
-                jax.random.normal(jax.random.PRNGKey(44), (M,)) + 1j * jax.random.normal(jax.random.PRNGKey(45), (M,))
+                jax.random.normal(jax.random.PRNGKey(44), (M,))
+                + 1j * jax.random.normal(jax.random.PRNGKey(45), (M,))
             ).astype(jnp.complex128)
 
             def loss(c):
@@ -397,9 +422,12 @@ class TestGradientFiniteDifference:
             M, N1, N2 = 15, 8, 10
             key = jax.random.PRNGKey(42)
             x = jax.random.uniform(key, (M,), minval=-jnp.pi, maxval=jnp.pi).astype(jnp.float64)
-            y = jax.random.uniform(jax.random.PRNGKey(43), (M,), minval=-jnp.pi, maxval=jnp.pi).astype(jnp.float64)
+            y = jax.random.uniform(
+                jax.random.PRNGKey(43), (M,), minval=-jnp.pi, maxval=jnp.pi
+            ).astype(jnp.float64)
             c = (
-                jax.random.normal(jax.random.PRNGKey(44), (M,)) + 1j * jax.random.normal(jax.random.PRNGKey(45), (M,))
+                jax.random.normal(jax.random.PRNGKey(44), (M,))
+                + 1j * jax.random.normal(jax.random.PRNGKey(45), (M,))
             ).astype(jnp.complex128)
 
             def loss_x(x):
@@ -445,7 +473,9 @@ class TestGradientFiniteDifference:
             M, N1, N2 = 15, 8, 10
             key = jax.random.PRNGKey(42)
             x = jax.random.uniform(key, (M,), minval=-jnp.pi, maxval=jnp.pi).astype(jnp.float64)
-            y = jax.random.uniform(jax.random.PRNGKey(43), (M,), minval=-jnp.pi, maxval=jnp.pi).astype(jnp.float64)
+            y = jax.random.uniform(
+                jax.random.PRNGKey(43), (M,), minval=-jnp.pi, maxval=jnp.pi
+            ).astype(jnp.float64)
             # f has shape (N2, N1) per JAX convention
             f = (
                 jax.random.normal(jax.random.PRNGKey(44), (N2, N1))
@@ -485,7 +515,9 @@ class TestGradientFiniteDifference:
             M, N1, N2 = 15, 8, 10
             key = jax.random.PRNGKey(42)
             x = jax.random.uniform(key, (M,), minval=-jnp.pi, maxval=jnp.pi).astype(jnp.float64)
-            y = jax.random.uniform(jax.random.PRNGKey(43), (M,), minval=-jnp.pi, maxval=jnp.pi).astype(jnp.float64)
+            y = jax.random.uniform(
+                jax.random.PRNGKey(43), (M,), minval=-jnp.pi, maxval=jnp.pi
+            ).astype(jnp.float64)
             f = (
                 jax.random.normal(jax.random.PRNGKey(44), (N2, N1))
                 + 1j * jax.random.normal(jax.random.PRNGKey(45), (N2, N1))
@@ -532,10 +564,15 @@ class TestGradientFiniteDifference:
             M, N1, N2, N3 = 10, 4, 4, 4
             key = jax.random.PRNGKey(42)
             x = jax.random.uniform(key, (M,), minval=-jnp.pi, maxval=jnp.pi).astype(jnp.float64)
-            y = jax.random.uniform(jax.random.PRNGKey(43), (M,), minval=-jnp.pi, maxval=jnp.pi).astype(jnp.float64)
-            z = jax.random.uniform(jax.random.PRNGKey(44), (M,), minval=-jnp.pi, maxval=jnp.pi).astype(jnp.float64)
+            y = jax.random.uniform(
+                jax.random.PRNGKey(43), (M,), minval=-jnp.pi, maxval=jnp.pi
+            ).astype(jnp.float64)
+            z = jax.random.uniform(
+                jax.random.PRNGKey(44), (M,), minval=-jnp.pi, maxval=jnp.pi
+            ).astype(jnp.float64)
             c = (
-                jax.random.normal(jax.random.PRNGKey(45), (M,)) + 1j * jax.random.normal(jax.random.PRNGKey(46), (M,))
+                jax.random.normal(jax.random.PRNGKey(45), (M,))
+                + 1j * jax.random.normal(jax.random.PRNGKey(46), (M,))
             ).astype(jnp.complex128)
 
             def loss(c):
@@ -569,10 +606,15 @@ class TestGradientFiniteDifference:
             M, N1, N2, N3 = 10, 4, 4, 4
             key = jax.random.PRNGKey(42)
             x = jax.random.uniform(key, (M,), minval=-jnp.pi, maxval=jnp.pi).astype(jnp.float64)
-            y = jax.random.uniform(jax.random.PRNGKey(43), (M,), minval=-jnp.pi, maxval=jnp.pi).astype(jnp.float64)
-            z = jax.random.uniform(jax.random.PRNGKey(44), (M,), minval=-jnp.pi, maxval=jnp.pi).astype(jnp.float64)
+            y = jax.random.uniform(
+                jax.random.PRNGKey(43), (M,), minval=-jnp.pi, maxval=jnp.pi
+            ).astype(jnp.float64)
+            z = jax.random.uniform(
+                jax.random.PRNGKey(44), (M,), minval=-jnp.pi, maxval=jnp.pi
+            ).astype(jnp.float64)
             c = (
-                jax.random.normal(jax.random.PRNGKey(45), (M,)) + 1j * jax.random.normal(jax.random.PRNGKey(46), (M,))
+                jax.random.normal(jax.random.PRNGKey(45), (M,))
+                + 1j * jax.random.normal(jax.random.PRNGKey(46), (M,))
             ).astype(jnp.complex128)
 
             def loss_x(x):
@@ -635,8 +677,12 @@ class TestGradientFiniteDifference:
             M, N1, N2, N3 = 10, 4, 4, 4
             key = jax.random.PRNGKey(42)
             x = jax.random.uniform(key, (M,), minval=-jnp.pi, maxval=jnp.pi).astype(jnp.float64)
-            y = jax.random.uniform(jax.random.PRNGKey(43), (M,), minval=-jnp.pi, maxval=jnp.pi).astype(jnp.float64)
-            z = jax.random.uniform(jax.random.PRNGKey(44), (M,), minval=-jnp.pi, maxval=jnp.pi).astype(jnp.float64)
+            y = jax.random.uniform(
+                jax.random.PRNGKey(43), (M,), minval=-jnp.pi, maxval=jnp.pi
+            ).astype(jnp.float64)
+            z = jax.random.uniform(
+                jax.random.PRNGKey(44), (M,), minval=-jnp.pi, maxval=jnp.pi
+            ).astype(jnp.float64)
             # f has shape (N3, N2, N1) per JAX convention
             f = (
                 jax.random.normal(jax.random.PRNGKey(45), (N3, N2, N1))
@@ -682,9 +728,12 @@ class TestGradientFiniteDifferenceType3:
             key = jax.random.PRNGKey(42)
             x = jax.random.uniform(key, (M,), minval=-jnp.pi, maxval=jnp.pi).astype(jnp.float64)
             c = (
-                jax.random.normal(jax.random.PRNGKey(43), (M,)) + 1j * jax.random.normal(jax.random.PRNGKey(44), (M,))
+                jax.random.normal(jax.random.PRNGKey(43), (M,))
+                + 1j * jax.random.normal(jax.random.PRNGKey(44), (M,))
             ).astype(jnp.complex128)
-            s = jax.random.uniform(jax.random.PRNGKey(45), (N,), minval=-10, maxval=10).astype(jnp.float64)
+            s = jax.random.uniform(jax.random.PRNGKey(45), (N,), minval=-10, maxval=10).astype(
+                jnp.float64
+            )
 
             # Compute grid size needed for Type 3
             n_modes = compute_type3_grid_size(x, s, eps=1e-10)
@@ -721,9 +770,12 @@ class TestGradientFiniteDifferenceType3:
             key = jax.random.PRNGKey(42)
             x = jax.random.uniform(key, (M,), minval=-jnp.pi, maxval=jnp.pi).astype(jnp.float64)
             c = (
-                jax.random.normal(jax.random.PRNGKey(43), (M,)) + 1j * jax.random.normal(jax.random.PRNGKey(44), (M,))
+                jax.random.normal(jax.random.PRNGKey(43), (M,))
+                + 1j * jax.random.normal(jax.random.PRNGKey(44), (M,))
             ).astype(jnp.complex128)
-            s = jax.random.uniform(jax.random.PRNGKey(45), (N,), minval=-10, maxval=10).astype(jnp.float64)
+            s = jax.random.uniform(jax.random.PRNGKey(45), (N,), minval=-10, maxval=10).astype(
+                jnp.float64
+            )
 
             # Compute grid size needed for Type 3
             n_modes = compute_type3_grid_size(x, s, eps=1e-10)
@@ -755,9 +807,12 @@ class TestGradientFiniteDifferenceType3:
             key = jax.random.PRNGKey(42)
             x = jax.random.uniform(key, (M,), minval=-jnp.pi, maxval=jnp.pi).astype(jnp.float64)
             c = (
-                jax.random.normal(jax.random.PRNGKey(43), (M,)) + 1j * jax.random.normal(jax.random.PRNGKey(44), (M,))
+                jax.random.normal(jax.random.PRNGKey(43), (M,))
+                + 1j * jax.random.normal(jax.random.PRNGKey(44), (M,))
             ).astype(jnp.complex128)
-            s = jax.random.uniform(jax.random.PRNGKey(45), (N,), minval=-10, maxval=10).astype(jnp.float64)
+            s = jax.random.uniform(jax.random.PRNGKey(45), (N,), minval=-10, maxval=10).astype(
+                jnp.float64
+            )
 
             # Compute grid size needed for Type 3
             n_modes = compute_type3_grid_size(x, s, eps=1e-10)
@@ -788,12 +843,19 @@ class TestGradientFiniteDifferenceType3:
             M, N = 10, 15
             key = jax.random.PRNGKey(42)
             x = jax.random.uniform(key, (M,), minval=-jnp.pi, maxval=jnp.pi).astype(jnp.float64)
-            y = jax.random.uniform(jax.random.PRNGKey(43), (M,), minval=-jnp.pi, maxval=jnp.pi).astype(jnp.float64)
+            y = jax.random.uniform(
+                jax.random.PRNGKey(43), (M,), minval=-jnp.pi, maxval=jnp.pi
+            ).astype(jnp.float64)
             c = (
-                jax.random.normal(jax.random.PRNGKey(44), (M,)) + 1j * jax.random.normal(jax.random.PRNGKey(45), (M,))
+                jax.random.normal(jax.random.PRNGKey(44), (M,))
+                + 1j * jax.random.normal(jax.random.PRNGKey(45), (M,))
             ).astype(jnp.complex128)
-            s = jax.random.uniform(jax.random.PRNGKey(46), (N,), minval=-10, maxval=10).astype(jnp.float64)
-            t = jax.random.uniform(jax.random.PRNGKey(47), (N,), minval=-10, maxval=10).astype(jnp.float64)
+            s = jax.random.uniform(jax.random.PRNGKey(46), (N,), minval=-10, maxval=10).astype(
+                jnp.float64
+            )
+            t = jax.random.uniform(jax.random.PRNGKey(47), (N,), minval=-10, maxval=10).astype(
+                jnp.float64
+            )
 
             # Compute grid sizes needed for 2D Type 3
             x_extent = float(jnp.max(x) - jnp.min(x)) / 2
@@ -833,12 +895,19 @@ class TestGradientFiniteDifferenceType3:
             M, N = 10, 15
             key = jax.random.PRNGKey(42)
             x = jax.random.uniform(key, (M,), minval=-jnp.pi, maxval=jnp.pi).astype(jnp.float64)
-            y = jax.random.uniform(jax.random.PRNGKey(43), (M,), minval=-jnp.pi, maxval=jnp.pi).astype(jnp.float64)
+            y = jax.random.uniform(
+                jax.random.PRNGKey(43), (M,), minval=-jnp.pi, maxval=jnp.pi
+            ).astype(jnp.float64)
             c = (
-                jax.random.normal(jax.random.PRNGKey(44), (M,)) + 1j * jax.random.normal(jax.random.PRNGKey(45), (M,))
+                jax.random.normal(jax.random.PRNGKey(44), (M,))
+                + 1j * jax.random.normal(jax.random.PRNGKey(45), (M,))
             ).astype(jnp.complex128)
-            s = jax.random.uniform(jax.random.PRNGKey(46), (N,), minval=-10, maxval=10).astype(jnp.float64)
-            t = jax.random.uniform(jax.random.PRNGKey(47), (N,), minval=-10, maxval=10).astype(jnp.float64)
+            s = jax.random.uniform(jax.random.PRNGKey(46), (N,), minval=-10, maxval=10).astype(
+                jnp.float64
+            )
+            t = jax.random.uniform(jax.random.PRNGKey(47), (N,), minval=-10, maxval=10).astype(
+                jnp.float64
+            )
 
             # Compute grid sizes needed for 2D Type 3
             x_extent = float(jnp.max(x) - jnp.min(x)) / 2
@@ -893,16 +962,20 @@ class TestJVPFiniteDifference:
             key = jax.random.PRNGKey(42)
             x = jax.random.uniform(key, (M,), minval=-jnp.pi, maxval=jnp.pi).astype(jnp.float64)
             c = (
-                jax.random.normal(jax.random.PRNGKey(43), (M,)) + 1j * jax.random.normal(jax.random.PRNGKey(44), (M,))
+                jax.random.normal(jax.random.PRNGKey(43), (M,))
+                + 1j * jax.random.normal(jax.random.PRNGKey(44), (M,))
             ).astype(jnp.complex128)
 
             # Random tangent direction for c
             dc = (
-                jax.random.normal(jax.random.PRNGKey(45), (M,)) + 1j * jax.random.normal(jax.random.PRNGKey(46), (M,))
+                jax.random.normal(jax.random.PRNGKey(45), (M,))
+                + 1j * jax.random.normal(jax.random.PRNGKey(46), (M,))
             ).astype(jnp.complex128)
 
             # Compute JVP
-            primals, tangents = jax.jvp(lambda c: nufft1d1_jvp(x, c, n_modes, eps=1e-10), (c,), (dc,))
+            primals, tangents = jax.jvp(
+                lambda c: nufft1d1_jvp(x, c, n_modes, eps=1e-10), (c,), (dc,)
+            )
 
             # Finite difference approximation
             eps = 1e-7
@@ -925,14 +998,17 @@ class TestJVPFiniteDifference:
             key = jax.random.PRNGKey(42)
             x = jax.random.uniform(key, (M,), minval=-jnp.pi, maxval=jnp.pi).astype(jnp.float64)
             c = (
-                jax.random.normal(jax.random.PRNGKey(43), (M,)) + 1j * jax.random.normal(jax.random.PRNGKey(44), (M,))
+                jax.random.normal(jax.random.PRNGKey(43), (M,))
+                + 1j * jax.random.normal(jax.random.PRNGKey(44), (M,))
             ).astype(jnp.complex128)
 
             # Random tangent direction for x
             dx = jax.random.normal(jax.random.PRNGKey(47), (M,)).astype(jnp.float64) * 0.1
 
             # Compute JVP
-            primals, tangents = jax.jvp(lambda x: nufft1d1_jvp(x, c, n_modes, eps=1e-10), (x,), (dx,))
+            primals, tangents = jax.jvp(
+                lambda x: nufft1d1_jvp(x, c, n_modes, eps=1e-10), (x,), (dx,)
+            )
 
             # Finite difference approximation
             eps = 1e-7
@@ -955,17 +1031,21 @@ class TestJVPFiniteDifference:
             key = jax.random.PRNGKey(42)
             x = jax.random.uniform(key, (M,), minval=-jnp.pi, maxval=jnp.pi).astype(jnp.float64)
             c = (
-                jax.random.normal(jax.random.PRNGKey(43), (M,)) + 1j * jax.random.normal(jax.random.PRNGKey(44), (M,))
+                jax.random.normal(jax.random.PRNGKey(43), (M,))
+                + 1j * jax.random.normal(jax.random.PRNGKey(44), (M,))
             ).astype(jnp.complex128)
 
             # Random tangent directions
             dx = jax.random.normal(jax.random.PRNGKey(47), (M,)).astype(jnp.float64) * 0.1
             dc = (
-                jax.random.normal(jax.random.PRNGKey(45), (M,)) + 1j * jax.random.normal(jax.random.PRNGKey(46), (M,))
+                jax.random.normal(jax.random.PRNGKey(45), (M,))
+                + 1j * jax.random.normal(jax.random.PRNGKey(46), (M,))
             ).astype(jnp.complex128)
 
             # Compute JVP with both tangents
-            primals, tangents = jax.jvp(lambda x, c: nufft1d1_jvp(x, c, n_modes, eps=1e-10), (x, c), (dx, dc))
+            primals, tangents = jax.jvp(
+                lambda x, c: nufft1d1_jvp(x, c, n_modes, eps=1e-10), (x, c), (dx, dc)
+            )
 
             # Finite difference approximation
             eps = 1e-7
@@ -1065,7 +1145,9 @@ class TestJVPFiniteDifference:
             ).astype(jnp.complex128)
 
             # Compute JVP with both tangents
-            primals, tangents = jax.jvp(lambda x, f: nufft1d2_jvp(x, f, eps=1e-10), (x, f), (dx, df))
+            primals, tangents = jax.jvp(
+                lambda x, f: nufft1d2_jvp(x, f, eps=1e-10), (x, f), (dx, df)
+            )
 
             # Finite difference approximation
             eps = 1e-7
@@ -1092,15 +1174,21 @@ class TestJVPFiniteDifference:
             n_modes = (n1, n2)
             key = jax.random.PRNGKey(42)
             x = jax.random.uniform(key, (M,), minval=-jnp.pi, maxval=jnp.pi).astype(jnp.float64)
-            y = jax.random.uniform(jax.random.PRNGKey(43), (M,), minval=-jnp.pi, maxval=jnp.pi).astype(jnp.float64)
+            y = jax.random.uniform(
+                jax.random.PRNGKey(43), (M,), minval=-jnp.pi, maxval=jnp.pi
+            ).astype(jnp.float64)
             c = (
-                jax.random.normal(jax.random.PRNGKey(44), (M,)) + 1j * jax.random.normal(jax.random.PRNGKey(45), (M,))
+                jax.random.normal(jax.random.PRNGKey(44), (M,))
+                + 1j * jax.random.normal(jax.random.PRNGKey(45), (M,))
             ).astype(jnp.complex128)
             dc = (
-                jax.random.normal(jax.random.PRNGKey(46), (M,)) + 1j * jax.random.normal(jax.random.PRNGKey(47), (M,))
+                jax.random.normal(jax.random.PRNGKey(46), (M,))
+                + 1j * jax.random.normal(jax.random.PRNGKey(47), (M,))
             ).astype(jnp.complex128)
 
-            primals, tangents = jax.jvp(lambda c: nufft2d1_jvp(x, y, c, n_modes, eps=1e-10), (c,), (dc,))
+            primals, tangents = jax.jvp(
+                lambda c: nufft2d1_jvp(x, y, c, n_modes, eps=1e-10), (c,), (dc,)
+            )
 
             eps = 1e-7
             f_plus = nufft2d1_jvp(x, y, c + eps * dc, n_modes, eps=1e-10)
@@ -1116,21 +1204,26 @@ class TestJVPFiniteDifference:
             n_modes = (n1, n2)
             key = jax.random.PRNGKey(42)
             x = jax.random.uniform(key, (M,), minval=-jnp.pi, maxval=jnp.pi).astype(jnp.float64)
-            y = jax.random.uniform(jax.random.PRNGKey(43), (M,), minval=-jnp.pi, maxval=jnp.pi).astype(jnp.float64)
+            y = jax.random.uniform(
+                jax.random.PRNGKey(43), (M,), minval=-jnp.pi, maxval=jnp.pi
+            ).astype(jnp.float64)
             c = (
-                jax.random.normal(jax.random.PRNGKey(44), (M,)) + 1j * jax.random.normal(jax.random.PRNGKey(45), (M,))
+                jax.random.normal(jax.random.PRNGKey(44), (M,))
+                + 1j * jax.random.normal(jax.random.PRNGKey(45), (M,))
             ).astype(jnp.complex128)
             dx = jax.random.normal(jax.random.PRNGKey(46), (M,)).astype(jnp.float64) * 0.1
             dy = jax.random.normal(jax.random.PRNGKey(47), (M,)).astype(jnp.float64) * 0.1
 
-            primals, tangents = jax.jvp(lambda x, y: nufft2d1_jvp(x, y, c, n_modes, eps=1e-10), (x, y), (dx, dy))
+            primals, tangents = jax.jvp(
+                lambda x, y: nufft2d1_jvp(x, y, c, n_modes, eps=1e-10), (x, y), (dx, dy)
+            )
 
             eps = 1e-7
             f_plus = nufft2d1_jvp(x + eps * dx, y + eps * dy, c, n_modes, eps=1e-10)
             f_minus = nufft2d1_jvp(x - eps * dx, y - eps * dy, c, n_modes, eps=1e-10)
             fd_tangent = (f_plus - f_minus) / (2 * eps)
 
-            np.testing.assert_allclose(tangents, fd_tangent, rtol=1e-5, atol=2e-8)
+            np.testing.assert_allclose(tangents, fd_tangent, rtol=1e-5, atol=4e-8)
 
     # =========================================================================
     # 2D Type 2 JVP Tests
@@ -1142,7 +1235,9 @@ class TestJVPFiniteDifference:
             M, n1, n2 = 20, 10, 12
             key = jax.random.PRNGKey(42)
             x = jax.random.uniform(key, (M,), minval=-jnp.pi, maxval=jnp.pi).astype(jnp.float64)
-            y = jax.random.uniform(jax.random.PRNGKey(43), (M,), minval=-jnp.pi, maxval=jnp.pi).astype(jnp.float64)
+            y = jax.random.uniform(
+                jax.random.PRNGKey(43), (M,), minval=-jnp.pi, maxval=jnp.pi
+            ).astype(jnp.float64)
             f = (
                 jax.random.normal(jax.random.PRNGKey(44), (n2, n1))
                 + 1j * jax.random.normal(jax.random.PRNGKey(45), (n2, n1))
@@ -1167,7 +1262,9 @@ class TestJVPFiniteDifference:
             M, n1, n2 = 20, 10, 12
             key = jax.random.PRNGKey(42)
             x = jax.random.uniform(key, (M,), minval=-jnp.pi, maxval=jnp.pi).astype(jnp.float64)
-            y = jax.random.uniform(jax.random.PRNGKey(43), (M,), minval=-jnp.pi, maxval=jnp.pi).astype(jnp.float64)
+            y = jax.random.uniform(
+                jax.random.PRNGKey(43), (M,), minval=-jnp.pi, maxval=jnp.pi
+            ).astype(jnp.float64)
             f = (
                 jax.random.normal(jax.random.PRNGKey(44), (n2, n1))
                 + 1j * jax.random.normal(jax.random.PRNGKey(45), (n2, n1))
@@ -1175,7 +1272,9 @@ class TestJVPFiniteDifference:
             dx = jax.random.normal(jax.random.PRNGKey(46), (M,)).astype(jnp.float64) * 0.1
             dy = jax.random.normal(jax.random.PRNGKey(47), (M,)).astype(jnp.float64) * 0.1
 
-            primals, tangents = jax.jvp(lambda x, y: nufft2d2_jvp(x, y, f, eps=1e-10), (x, y), (dx, dy))
+            primals, tangents = jax.jvp(
+                lambda x, y: nufft2d2_jvp(x, y, f, eps=1e-10), (x, y), (dx, dy)
+            )
 
             eps = 1e-7
             c_plus = nufft2d2_jvp(x + eps * dx, y + eps * dy, f, eps=1e-10)
@@ -1195,16 +1294,24 @@ class TestJVPFiniteDifference:
             n_modes = (n1, n2, n3)
             key = jax.random.PRNGKey(42)
             x = jax.random.uniform(key, (M,), minval=-jnp.pi, maxval=jnp.pi).astype(jnp.float64)
-            y = jax.random.uniform(jax.random.PRNGKey(43), (M,), minval=-jnp.pi, maxval=jnp.pi).astype(jnp.float64)
-            z = jax.random.uniform(jax.random.PRNGKey(44), (M,), minval=-jnp.pi, maxval=jnp.pi).astype(jnp.float64)
+            y = jax.random.uniform(
+                jax.random.PRNGKey(43), (M,), minval=-jnp.pi, maxval=jnp.pi
+            ).astype(jnp.float64)
+            z = jax.random.uniform(
+                jax.random.PRNGKey(44), (M,), minval=-jnp.pi, maxval=jnp.pi
+            ).astype(jnp.float64)
             c = (
-                jax.random.normal(jax.random.PRNGKey(45), (M,)) + 1j * jax.random.normal(jax.random.PRNGKey(46), (M,))
+                jax.random.normal(jax.random.PRNGKey(45), (M,))
+                + 1j * jax.random.normal(jax.random.PRNGKey(46), (M,))
             ).astype(jnp.complex128)
             dc = (
-                jax.random.normal(jax.random.PRNGKey(47), (M,)) + 1j * jax.random.normal(jax.random.PRNGKey(48), (M,))
+                jax.random.normal(jax.random.PRNGKey(47), (M,))
+                + 1j * jax.random.normal(jax.random.PRNGKey(48), (M,))
             ).astype(jnp.complex128)
 
-            primals, tangents = jax.jvp(lambda c: nufft3d1_jvp(x, y, z, c, n_modes, eps=1e-10), (c,), (dc,))
+            primals, tangents = jax.jvp(
+                lambda c: nufft3d1_jvp(x, y, z, c, n_modes, eps=1e-10), (c,), (dc,)
+            )
 
             eps = 1e-7
             f_plus = nufft3d1_jvp(x, y, z, c + eps * dc, n_modes, eps=1e-10)
@@ -1220,10 +1327,15 @@ class TestJVPFiniteDifference:
             n_modes = (n1, n2, n3)
             key = jax.random.PRNGKey(42)
             x = jax.random.uniform(key, (M,), minval=-jnp.pi, maxval=jnp.pi).astype(jnp.float64)
-            y = jax.random.uniform(jax.random.PRNGKey(43), (M,), minval=-jnp.pi, maxval=jnp.pi).astype(jnp.float64)
-            z = jax.random.uniform(jax.random.PRNGKey(44), (M,), minval=-jnp.pi, maxval=jnp.pi).astype(jnp.float64)
+            y = jax.random.uniform(
+                jax.random.PRNGKey(43), (M,), minval=-jnp.pi, maxval=jnp.pi
+            ).astype(jnp.float64)
+            z = jax.random.uniform(
+                jax.random.PRNGKey(44), (M,), minval=-jnp.pi, maxval=jnp.pi
+            ).astype(jnp.float64)
             c = (
-                jax.random.normal(jax.random.PRNGKey(45), (M,)) + 1j * jax.random.normal(jax.random.PRNGKey(46), (M,))
+                jax.random.normal(jax.random.PRNGKey(45), (M,))
+                + 1j * jax.random.normal(jax.random.PRNGKey(46), (M,))
             ).astype(jnp.complex128)
             dx = jax.random.normal(jax.random.PRNGKey(47), (M,)).astype(jnp.float64) * 0.1
             dy = jax.random.normal(jax.random.PRNGKey(48), (M,)).astype(jnp.float64) * 0.1
@@ -1240,7 +1352,7 @@ class TestJVPFiniteDifference:
             f_minus = nufft3d1_jvp(x - eps * dx, y - eps * dy, z - eps * dz, c, n_modes, eps=1e-10)
             fd_tangent = (f_plus - f_minus) / (2 * eps)
 
-            np.testing.assert_allclose(tangents, fd_tangent, rtol=1e-5, atol=1e-8)
+            np.testing.assert_allclose(tangents, fd_tangent, rtol=1e-5, atol=4e-8)
 
     # =========================================================================
     # 3D Type 2 JVP Tests
@@ -1252,8 +1364,12 @@ class TestJVPFiniteDifference:
             M, n1, n2, n3 = 15, 6, 8, 7
             key = jax.random.PRNGKey(42)
             x = jax.random.uniform(key, (M,), minval=-jnp.pi, maxval=jnp.pi).astype(jnp.float64)
-            y = jax.random.uniform(jax.random.PRNGKey(43), (M,), minval=-jnp.pi, maxval=jnp.pi).astype(jnp.float64)
-            z = jax.random.uniform(jax.random.PRNGKey(44), (M,), minval=-jnp.pi, maxval=jnp.pi).astype(jnp.float64)
+            y = jax.random.uniform(
+                jax.random.PRNGKey(43), (M,), minval=-jnp.pi, maxval=jnp.pi
+            ).astype(jnp.float64)
+            z = jax.random.uniform(
+                jax.random.PRNGKey(44), (M,), minval=-jnp.pi, maxval=jnp.pi
+            ).astype(jnp.float64)
             f = (
                 jax.random.normal(jax.random.PRNGKey(45), (n3, n2, n1))
                 + 1j * jax.random.normal(jax.random.PRNGKey(46), (n3, n2, n1))
@@ -1278,8 +1394,12 @@ class TestJVPFiniteDifference:
             M, n1, n2, n3 = 15, 6, 8, 7
             key = jax.random.PRNGKey(42)
             x = jax.random.uniform(key, (M,), minval=-jnp.pi, maxval=jnp.pi).astype(jnp.float64)
-            y = jax.random.uniform(jax.random.PRNGKey(43), (M,), minval=-jnp.pi, maxval=jnp.pi).astype(jnp.float64)
-            z = jax.random.uniform(jax.random.PRNGKey(44), (M,), minval=-jnp.pi, maxval=jnp.pi).astype(jnp.float64)
+            y = jax.random.uniform(
+                jax.random.PRNGKey(43), (M,), minval=-jnp.pi, maxval=jnp.pi
+            ).astype(jnp.float64)
+            z = jax.random.uniform(
+                jax.random.PRNGKey(44), (M,), minval=-jnp.pi, maxval=jnp.pi
+            ).astype(jnp.float64)
             f = (
                 jax.random.normal(jax.random.PRNGKey(45), (n3, n2, n1))
                 + 1j * jax.random.normal(jax.random.PRNGKey(46), (n3, n2, n1))
@@ -1288,7 +1408,9 @@ class TestJVPFiniteDifference:
             dy = jax.random.normal(jax.random.PRNGKey(48), (M,)).astype(jnp.float64) * 0.1
             dz = jax.random.normal(jax.random.PRNGKey(49), (M,)).astype(jnp.float64) * 0.1
 
-            primals, tangents = jax.jvp(lambda x, y, z: nufft3d2_jvp(x, y, z, f, eps=1e-10), (x, y, z), (dx, dy, dz))
+            primals, tangents = jax.jvp(
+                lambda x, y, z: nufft3d2_jvp(x, y, z, f, eps=1e-10), (x, y, z), (dx, dy, dz)
+            )
 
             eps = 1e-7
             c_plus = nufft3d2_jvp(x + eps * dx, y + eps * dy, z + eps * dz, f, eps=1e-10)

--- a/tests/test_adjoint.py
+++ b/tests/test_adjoint.py
@@ -36,9 +36,7 @@ class TestGradientRelationships:
         M, N = 100, 64
         key = jax.random.PRNGKey(42)
         x = jax.random.uniform(key, (M,), minval=-jnp.pi, maxval=jnp.pi)
-        c = jax.random.normal(jax.random.PRNGKey(43), (M,)) + 1j * jax.random.normal(
-            jax.random.PRNGKey(44), (M,)
-        )
+        c = jax.random.normal(jax.random.PRNGKey(43), (M,)) + 1j * jax.random.normal(jax.random.PRNGKey(44), (M,))
         c = c.astype(jnp.complex64)
 
         # Gradient w.r.t. c should be well-defined
@@ -57,9 +55,7 @@ class TestGradientRelationships:
         M, N = 100, 64
         key = jax.random.PRNGKey(42)
         x = jax.random.uniform(key, (M,), minval=-jnp.pi, maxval=jnp.pi)
-        c = jax.random.normal(jax.random.PRNGKey(43), (M,)) + 1j * jax.random.normal(
-            jax.random.PRNGKey(44), (M,)
-        )
+        c = jax.random.normal(jax.random.PRNGKey(43), (M,)) + 1j * jax.random.normal(jax.random.PRNGKey(44), (M,))
         c = c.astype(jnp.complex64)
 
         def loss(x):
@@ -75,9 +71,7 @@ class TestGradientRelationships:
         M, N = 100, 64
         key = jax.random.PRNGKey(42)
         x = jax.random.uniform(key, (M,), minval=-jnp.pi, maxval=jnp.pi)
-        f = jax.random.normal(jax.random.PRNGKey(43), (N,)) + 1j * jax.random.normal(
-            jax.random.PRNGKey(44), (N,)
-        )
+        f = jax.random.normal(jax.random.PRNGKey(43), (N,)) + 1j * jax.random.normal(jax.random.PRNGKey(44), (N,))
         f = f.astype(jnp.complex64)
 
         def loss(f):
@@ -103,9 +97,7 @@ class TestSelfAdjointRoundtrip:
         M, N = 128, 128
         key = jax.random.PRNGKey(42)
         x = jax.random.uniform(key, (M,), minval=-jnp.pi, maxval=jnp.pi)
-        c = jax.random.normal(jax.random.PRNGKey(43), (M,)) + 1j * jax.random.normal(
-            jax.random.PRNGKey(44), (M,)
-        )
+        c = jax.random.normal(jax.random.PRNGKey(43), (M,)) + 1j * jax.random.normal(jax.random.PRNGKey(44), (M,))
         c = c.astype(jnp.complex64)
 
         # Type 1: nonuniform -> uniform
@@ -132,9 +124,7 @@ class TestSelfAdjointRoundtrip:
         key = jax.random.PRNGKey(42)
         x = jax.random.uniform(key, (M,), minval=-jnp.pi, maxval=jnp.pi)
         y = jax.random.uniform(jax.random.PRNGKey(43), (M,), minval=-jnp.pi, maxval=jnp.pi)
-        c = jax.random.normal(jax.random.PRNGKey(44), (M,)) + 1j * jax.random.normal(
-            jax.random.PRNGKey(45), (M,)
-        )
+        c = jax.random.normal(jax.random.PRNGKey(44), (M,)) + 1j * jax.random.normal(jax.random.PRNGKey(45), (M,))
         c = c.astype(jnp.complex64)
 
         F = nufft2d1(x, y, c, (N1, N2), eps=1e-6, isign=1)
@@ -154,9 +144,7 @@ class TestSelfAdjointRoundtrip:
         N = 64
         M = N  # Same number of points as modes
         x = jnp.linspace(-jnp.pi, jnp.pi, M, endpoint=False)
-        c = jax.random.normal(jax.random.PRNGKey(42), (M,)) + 1j * jax.random.normal(
-            jax.random.PRNGKey(43), (M,)
-        )
+        c = jax.random.normal(jax.random.PRNGKey(42), (M,)) + 1j * jax.random.normal(jax.random.PRNGKey(43), (M,))
         c = c.astype(jnp.complex64)
 
         # Type 1 -> Type 2 with uniform spacing should reconstruct well
@@ -177,9 +165,7 @@ class TestGradient2D:
         key = jax.random.PRNGKey(42)
         x = jax.random.uniform(key, (M,), minval=-jnp.pi, maxval=jnp.pi)
         y = jax.random.uniform(jax.random.PRNGKey(43), (M,), minval=-jnp.pi, maxval=jnp.pi)
-        c = jax.random.normal(jax.random.PRNGKey(44), (M,)) + 1j * jax.random.normal(
-            jax.random.PRNGKey(45), (M,)
-        )
+        c = jax.random.normal(jax.random.PRNGKey(44), (M,)) + 1j * jax.random.normal(jax.random.PRNGKey(45), (M,))
         c = c.astype(jnp.complex64)
 
         def loss(c):
@@ -196,9 +182,7 @@ class TestGradient2D:
         key = jax.random.PRNGKey(42)
         x = jax.random.uniform(key, (M,), minval=-jnp.pi, maxval=jnp.pi)
         y = jax.random.uniform(jax.random.PRNGKey(43), (M,), minval=-jnp.pi, maxval=jnp.pi)
-        c = jax.random.normal(jax.random.PRNGKey(44), (M,)) + 1j * jax.random.normal(
-            jax.random.PRNGKey(45), (M,)
-        )
+        c = jax.random.normal(jax.random.PRNGKey(44), (M,)) + 1j * jax.random.normal(jax.random.PRNGKey(45), (M,))
         c = c.astype(jnp.complex64)
 
         def loss(x, y):
@@ -222,9 +206,7 @@ class TestGradient3D:
         x = jax.random.uniform(key, (M,), minval=-jnp.pi, maxval=jnp.pi)
         y = jax.random.uniform(jax.random.PRNGKey(43), (M,), minval=-jnp.pi, maxval=jnp.pi)
         z = jax.random.uniform(jax.random.PRNGKey(44), (M,), minval=-jnp.pi, maxval=jnp.pi)
-        c = jax.random.normal(jax.random.PRNGKey(45), (M,)) + 1j * jax.random.normal(
-            jax.random.PRNGKey(46), (M,)
-        )
+        c = jax.random.normal(jax.random.PRNGKey(45), (M,)) + 1j * jax.random.normal(jax.random.PRNGKey(46), (M,))
         c = c.astype(jnp.complex64)
 
         def loss(c):
@@ -250,8 +232,7 @@ class TestGradientFiniteDifference:
             key = jax.random.PRNGKey(42)
             x = jax.random.uniform(key, (M,), minval=-jnp.pi, maxval=jnp.pi).astype(jnp.float64)
             c = (
-                jax.random.normal(jax.random.PRNGKey(43), (M,))
-                + 1j * jax.random.normal(jax.random.PRNGKey(44), (M,))
+                jax.random.normal(jax.random.PRNGKey(43), (M,)) + 1j * jax.random.normal(jax.random.PRNGKey(44), (M,))
             ).astype(jnp.complex128)
 
             def loss(c):
@@ -286,8 +267,7 @@ class TestGradientFiniteDifference:
             key = jax.random.PRNGKey(42)
             x = jax.random.uniform(key, (M,), minval=-jnp.pi, maxval=jnp.pi).astype(jnp.float64)
             c = (
-                jax.random.normal(jax.random.PRNGKey(43), (M,))
-                + 1j * jax.random.normal(jax.random.PRNGKey(44), (M,))
+                jax.random.normal(jax.random.PRNGKey(43), (M,)) + 1j * jax.random.normal(jax.random.PRNGKey(44), (M,))
             ).astype(jnp.complex128)
 
             def loss(x):
@@ -317,8 +297,7 @@ class TestGradientFiniteDifference:
             key = jax.random.PRNGKey(42)
             x = jax.random.uniform(key, (M,), minval=-jnp.pi, maxval=jnp.pi).astype(jnp.float64)
             f = (
-                jax.random.normal(jax.random.PRNGKey(43), (N,))
-                + 1j * jax.random.normal(jax.random.PRNGKey(44), (N,))
+                jax.random.normal(jax.random.PRNGKey(43), (N,)) + 1j * jax.random.normal(jax.random.PRNGKey(44), (N,))
             ).astype(jnp.complex128)
 
             def loss(f):
@@ -353,8 +332,7 @@ class TestGradientFiniteDifference:
             key = jax.random.PRNGKey(42)
             x = jax.random.uniform(key, (M,), minval=-jnp.pi, maxval=jnp.pi).astype(jnp.float64)
             f = (
-                jax.random.normal(jax.random.PRNGKey(43), (N,))
-                + 1j * jax.random.normal(jax.random.PRNGKey(44), (N,))
+                jax.random.normal(jax.random.PRNGKey(43), (N,)) + 1j * jax.random.normal(jax.random.PRNGKey(44), (N,))
             ).astype(jnp.complex128)
 
             def loss(x):
@@ -383,12 +361,9 @@ class TestGradientFiniteDifference:
             M, N1, N2 = 15, 8, 10
             key = jax.random.PRNGKey(42)
             x = jax.random.uniform(key, (M,), minval=-jnp.pi, maxval=jnp.pi).astype(jnp.float64)
-            y = jax.random.uniform(
-                jax.random.PRNGKey(43), (M,), minval=-jnp.pi, maxval=jnp.pi
-            ).astype(jnp.float64)
+            y = jax.random.uniform(jax.random.PRNGKey(43), (M,), minval=-jnp.pi, maxval=jnp.pi).astype(jnp.float64)
             c = (
-                jax.random.normal(jax.random.PRNGKey(44), (M,))
-                + 1j * jax.random.normal(jax.random.PRNGKey(45), (M,))
+                jax.random.normal(jax.random.PRNGKey(44), (M,)) + 1j * jax.random.normal(jax.random.PRNGKey(45), (M,))
             ).astype(jnp.complex128)
 
             def loss(c):
@@ -422,12 +397,9 @@ class TestGradientFiniteDifference:
             M, N1, N2 = 15, 8, 10
             key = jax.random.PRNGKey(42)
             x = jax.random.uniform(key, (M,), minval=-jnp.pi, maxval=jnp.pi).astype(jnp.float64)
-            y = jax.random.uniform(
-                jax.random.PRNGKey(43), (M,), minval=-jnp.pi, maxval=jnp.pi
-            ).astype(jnp.float64)
+            y = jax.random.uniform(jax.random.PRNGKey(43), (M,), minval=-jnp.pi, maxval=jnp.pi).astype(jnp.float64)
             c = (
-                jax.random.normal(jax.random.PRNGKey(44), (M,))
-                + 1j * jax.random.normal(jax.random.PRNGKey(45), (M,))
+                jax.random.normal(jax.random.PRNGKey(44), (M,)) + 1j * jax.random.normal(jax.random.PRNGKey(45), (M,))
             ).astype(jnp.complex128)
 
             def loss_x(x):
@@ -473,9 +445,7 @@ class TestGradientFiniteDifference:
             M, N1, N2 = 15, 8, 10
             key = jax.random.PRNGKey(42)
             x = jax.random.uniform(key, (M,), minval=-jnp.pi, maxval=jnp.pi).astype(jnp.float64)
-            y = jax.random.uniform(
-                jax.random.PRNGKey(43), (M,), minval=-jnp.pi, maxval=jnp.pi
-            ).astype(jnp.float64)
+            y = jax.random.uniform(jax.random.PRNGKey(43), (M,), minval=-jnp.pi, maxval=jnp.pi).astype(jnp.float64)
             # f has shape (N2, N1) per JAX convention
             f = (
                 jax.random.normal(jax.random.PRNGKey(44), (N2, N1))
@@ -515,9 +485,7 @@ class TestGradientFiniteDifference:
             M, N1, N2 = 15, 8, 10
             key = jax.random.PRNGKey(42)
             x = jax.random.uniform(key, (M,), minval=-jnp.pi, maxval=jnp.pi).astype(jnp.float64)
-            y = jax.random.uniform(
-                jax.random.PRNGKey(43), (M,), minval=-jnp.pi, maxval=jnp.pi
-            ).astype(jnp.float64)
+            y = jax.random.uniform(jax.random.PRNGKey(43), (M,), minval=-jnp.pi, maxval=jnp.pi).astype(jnp.float64)
             f = (
                 jax.random.normal(jax.random.PRNGKey(44), (N2, N1))
                 + 1j * jax.random.normal(jax.random.PRNGKey(45), (N2, N1))
@@ -564,15 +532,10 @@ class TestGradientFiniteDifference:
             M, N1, N2, N3 = 10, 4, 4, 4
             key = jax.random.PRNGKey(42)
             x = jax.random.uniform(key, (M,), minval=-jnp.pi, maxval=jnp.pi).astype(jnp.float64)
-            y = jax.random.uniform(
-                jax.random.PRNGKey(43), (M,), minval=-jnp.pi, maxval=jnp.pi
-            ).astype(jnp.float64)
-            z = jax.random.uniform(
-                jax.random.PRNGKey(44), (M,), minval=-jnp.pi, maxval=jnp.pi
-            ).astype(jnp.float64)
+            y = jax.random.uniform(jax.random.PRNGKey(43), (M,), minval=-jnp.pi, maxval=jnp.pi).astype(jnp.float64)
+            z = jax.random.uniform(jax.random.PRNGKey(44), (M,), minval=-jnp.pi, maxval=jnp.pi).astype(jnp.float64)
             c = (
-                jax.random.normal(jax.random.PRNGKey(45), (M,))
-                + 1j * jax.random.normal(jax.random.PRNGKey(46), (M,))
+                jax.random.normal(jax.random.PRNGKey(45), (M,)) + 1j * jax.random.normal(jax.random.PRNGKey(46), (M,))
             ).astype(jnp.complex128)
 
             def loss(c):
@@ -606,15 +569,10 @@ class TestGradientFiniteDifference:
             M, N1, N2, N3 = 10, 4, 4, 4
             key = jax.random.PRNGKey(42)
             x = jax.random.uniform(key, (M,), minval=-jnp.pi, maxval=jnp.pi).astype(jnp.float64)
-            y = jax.random.uniform(
-                jax.random.PRNGKey(43), (M,), minval=-jnp.pi, maxval=jnp.pi
-            ).astype(jnp.float64)
-            z = jax.random.uniform(
-                jax.random.PRNGKey(44), (M,), minval=-jnp.pi, maxval=jnp.pi
-            ).astype(jnp.float64)
+            y = jax.random.uniform(jax.random.PRNGKey(43), (M,), minval=-jnp.pi, maxval=jnp.pi).astype(jnp.float64)
+            z = jax.random.uniform(jax.random.PRNGKey(44), (M,), minval=-jnp.pi, maxval=jnp.pi).astype(jnp.float64)
             c = (
-                jax.random.normal(jax.random.PRNGKey(45), (M,))
-                + 1j * jax.random.normal(jax.random.PRNGKey(46), (M,))
+                jax.random.normal(jax.random.PRNGKey(45), (M,)) + 1j * jax.random.normal(jax.random.PRNGKey(46), (M,))
             ).astype(jnp.complex128)
 
             def loss_x(x):
@@ -677,12 +635,8 @@ class TestGradientFiniteDifference:
             M, N1, N2, N3 = 10, 4, 4, 4
             key = jax.random.PRNGKey(42)
             x = jax.random.uniform(key, (M,), minval=-jnp.pi, maxval=jnp.pi).astype(jnp.float64)
-            y = jax.random.uniform(
-                jax.random.PRNGKey(43), (M,), minval=-jnp.pi, maxval=jnp.pi
-            ).astype(jnp.float64)
-            z = jax.random.uniform(
-                jax.random.PRNGKey(44), (M,), minval=-jnp.pi, maxval=jnp.pi
-            ).astype(jnp.float64)
+            y = jax.random.uniform(jax.random.PRNGKey(43), (M,), minval=-jnp.pi, maxval=jnp.pi).astype(jnp.float64)
+            z = jax.random.uniform(jax.random.PRNGKey(44), (M,), minval=-jnp.pi, maxval=jnp.pi).astype(jnp.float64)
             # f has shape (N3, N2, N1) per JAX convention
             f = (
                 jax.random.normal(jax.random.PRNGKey(45), (N3, N2, N1))
@@ -728,12 +682,9 @@ class TestGradientFiniteDifferenceType3:
             key = jax.random.PRNGKey(42)
             x = jax.random.uniform(key, (M,), minval=-jnp.pi, maxval=jnp.pi).astype(jnp.float64)
             c = (
-                jax.random.normal(jax.random.PRNGKey(43), (M,))
-                + 1j * jax.random.normal(jax.random.PRNGKey(44), (M,))
+                jax.random.normal(jax.random.PRNGKey(43), (M,)) + 1j * jax.random.normal(jax.random.PRNGKey(44), (M,))
             ).astype(jnp.complex128)
-            s = jax.random.uniform(jax.random.PRNGKey(45), (N,), minval=-10, maxval=10).astype(
-                jnp.float64
-            )
+            s = jax.random.uniform(jax.random.PRNGKey(45), (N,), minval=-10, maxval=10).astype(jnp.float64)
 
             # Compute grid size needed for Type 3
             n_modes = compute_type3_grid_size(x, s, eps=1e-10)
@@ -770,12 +721,9 @@ class TestGradientFiniteDifferenceType3:
             key = jax.random.PRNGKey(42)
             x = jax.random.uniform(key, (M,), minval=-jnp.pi, maxval=jnp.pi).astype(jnp.float64)
             c = (
-                jax.random.normal(jax.random.PRNGKey(43), (M,))
-                + 1j * jax.random.normal(jax.random.PRNGKey(44), (M,))
+                jax.random.normal(jax.random.PRNGKey(43), (M,)) + 1j * jax.random.normal(jax.random.PRNGKey(44), (M,))
             ).astype(jnp.complex128)
-            s = jax.random.uniform(jax.random.PRNGKey(45), (N,), minval=-10, maxval=10).astype(
-                jnp.float64
-            )
+            s = jax.random.uniform(jax.random.PRNGKey(45), (N,), minval=-10, maxval=10).astype(jnp.float64)
 
             # Compute grid size needed for Type 3
             n_modes = compute_type3_grid_size(x, s, eps=1e-10)
@@ -807,12 +755,9 @@ class TestGradientFiniteDifferenceType3:
             key = jax.random.PRNGKey(42)
             x = jax.random.uniform(key, (M,), minval=-jnp.pi, maxval=jnp.pi).astype(jnp.float64)
             c = (
-                jax.random.normal(jax.random.PRNGKey(43), (M,))
-                + 1j * jax.random.normal(jax.random.PRNGKey(44), (M,))
+                jax.random.normal(jax.random.PRNGKey(43), (M,)) + 1j * jax.random.normal(jax.random.PRNGKey(44), (M,))
             ).astype(jnp.complex128)
-            s = jax.random.uniform(jax.random.PRNGKey(45), (N,), minval=-10, maxval=10).astype(
-                jnp.float64
-            )
+            s = jax.random.uniform(jax.random.PRNGKey(45), (N,), minval=-10, maxval=10).astype(jnp.float64)
 
             # Compute grid size needed for Type 3
             n_modes = compute_type3_grid_size(x, s, eps=1e-10)
@@ -843,19 +788,12 @@ class TestGradientFiniteDifferenceType3:
             M, N = 10, 15
             key = jax.random.PRNGKey(42)
             x = jax.random.uniform(key, (M,), minval=-jnp.pi, maxval=jnp.pi).astype(jnp.float64)
-            y = jax.random.uniform(
-                jax.random.PRNGKey(43), (M,), minval=-jnp.pi, maxval=jnp.pi
-            ).astype(jnp.float64)
+            y = jax.random.uniform(jax.random.PRNGKey(43), (M,), minval=-jnp.pi, maxval=jnp.pi).astype(jnp.float64)
             c = (
-                jax.random.normal(jax.random.PRNGKey(44), (M,))
-                + 1j * jax.random.normal(jax.random.PRNGKey(45), (M,))
+                jax.random.normal(jax.random.PRNGKey(44), (M,)) + 1j * jax.random.normal(jax.random.PRNGKey(45), (M,))
             ).astype(jnp.complex128)
-            s = jax.random.uniform(jax.random.PRNGKey(46), (N,), minval=-10, maxval=10).astype(
-                jnp.float64
-            )
-            t = jax.random.uniform(jax.random.PRNGKey(47), (N,), minval=-10, maxval=10).astype(
-                jnp.float64
-            )
+            s = jax.random.uniform(jax.random.PRNGKey(46), (N,), minval=-10, maxval=10).astype(jnp.float64)
+            t = jax.random.uniform(jax.random.PRNGKey(47), (N,), minval=-10, maxval=10).astype(jnp.float64)
 
             # Compute grid sizes needed for 2D Type 3
             x_extent = float(jnp.max(x) - jnp.min(x)) / 2
@@ -895,19 +833,12 @@ class TestGradientFiniteDifferenceType3:
             M, N = 10, 15
             key = jax.random.PRNGKey(42)
             x = jax.random.uniform(key, (M,), minval=-jnp.pi, maxval=jnp.pi).astype(jnp.float64)
-            y = jax.random.uniform(
-                jax.random.PRNGKey(43), (M,), minval=-jnp.pi, maxval=jnp.pi
-            ).astype(jnp.float64)
+            y = jax.random.uniform(jax.random.PRNGKey(43), (M,), minval=-jnp.pi, maxval=jnp.pi).astype(jnp.float64)
             c = (
-                jax.random.normal(jax.random.PRNGKey(44), (M,))
-                + 1j * jax.random.normal(jax.random.PRNGKey(45), (M,))
+                jax.random.normal(jax.random.PRNGKey(44), (M,)) + 1j * jax.random.normal(jax.random.PRNGKey(45), (M,))
             ).astype(jnp.complex128)
-            s = jax.random.uniform(jax.random.PRNGKey(46), (N,), minval=-10, maxval=10).astype(
-                jnp.float64
-            )
-            t = jax.random.uniform(jax.random.PRNGKey(47), (N,), minval=-10, maxval=10).astype(
-                jnp.float64
-            )
+            s = jax.random.uniform(jax.random.PRNGKey(46), (N,), minval=-10, maxval=10).astype(jnp.float64)
+            t = jax.random.uniform(jax.random.PRNGKey(47), (N,), minval=-10, maxval=10).astype(jnp.float64)
 
             # Compute grid sizes needed for 2D Type 3
             x_extent = float(jnp.max(x) - jnp.min(x)) / 2
@@ -962,20 +893,16 @@ class TestJVPFiniteDifference:
             key = jax.random.PRNGKey(42)
             x = jax.random.uniform(key, (M,), minval=-jnp.pi, maxval=jnp.pi).astype(jnp.float64)
             c = (
-                jax.random.normal(jax.random.PRNGKey(43), (M,))
-                + 1j * jax.random.normal(jax.random.PRNGKey(44), (M,))
+                jax.random.normal(jax.random.PRNGKey(43), (M,)) + 1j * jax.random.normal(jax.random.PRNGKey(44), (M,))
             ).astype(jnp.complex128)
 
             # Random tangent direction for c
             dc = (
-                jax.random.normal(jax.random.PRNGKey(45), (M,))
-                + 1j * jax.random.normal(jax.random.PRNGKey(46), (M,))
+                jax.random.normal(jax.random.PRNGKey(45), (M,)) + 1j * jax.random.normal(jax.random.PRNGKey(46), (M,))
             ).astype(jnp.complex128)
 
             # Compute JVP
-            primals, tangents = jax.jvp(
-                lambda c: nufft1d1_jvp(x, c, n_modes, eps=1e-10), (c,), (dc,)
-            )
+            primals, tangents = jax.jvp(lambda c: nufft1d1_jvp(x, c, n_modes, eps=1e-10), (c,), (dc,))
 
             # Finite difference approximation
             eps = 1e-7
@@ -998,17 +925,14 @@ class TestJVPFiniteDifference:
             key = jax.random.PRNGKey(42)
             x = jax.random.uniform(key, (M,), minval=-jnp.pi, maxval=jnp.pi).astype(jnp.float64)
             c = (
-                jax.random.normal(jax.random.PRNGKey(43), (M,))
-                + 1j * jax.random.normal(jax.random.PRNGKey(44), (M,))
+                jax.random.normal(jax.random.PRNGKey(43), (M,)) + 1j * jax.random.normal(jax.random.PRNGKey(44), (M,))
             ).astype(jnp.complex128)
 
             # Random tangent direction for x
             dx = jax.random.normal(jax.random.PRNGKey(47), (M,)).astype(jnp.float64) * 0.1
 
             # Compute JVP
-            primals, tangents = jax.jvp(
-                lambda x: nufft1d1_jvp(x, c, n_modes, eps=1e-10), (x,), (dx,)
-            )
+            primals, tangents = jax.jvp(lambda x: nufft1d1_jvp(x, c, n_modes, eps=1e-10), (x,), (dx,))
 
             # Finite difference approximation
             eps = 1e-7
@@ -1031,21 +955,17 @@ class TestJVPFiniteDifference:
             key = jax.random.PRNGKey(42)
             x = jax.random.uniform(key, (M,), minval=-jnp.pi, maxval=jnp.pi).astype(jnp.float64)
             c = (
-                jax.random.normal(jax.random.PRNGKey(43), (M,))
-                + 1j * jax.random.normal(jax.random.PRNGKey(44), (M,))
+                jax.random.normal(jax.random.PRNGKey(43), (M,)) + 1j * jax.random.normal(jax.random.PRNGKey(44), (M,))
             ).astype(jnp.complex128)
 
             # Random tangent directions
             dx = jax.random.normal(jax.random.PRNGKey(47), (M,)).astype(jnp.float64) * 0.1
             dc = (
-                jax.random.normal(jax.random.PRNGKey(45), (M,))
-                + 1j * jax.random.normal(jax.random.PRNGKey(46), (M,))
+                jax.random.normal(jax.random.PRNGKey(45), (M,)) + 1j * jax.random.normal(jax.random.PRNGKey(46), (M,))
             ).astype(jnp.complex128)
 
             # Compute JVP with both tangents
-            primals, tangents = jax.jvp(
-                lambda x, c: nufft1d1_jvp(x, c, n_modes, eps=1e-10), (x, c), (dx, dc)
-            )
+            primals, tangents = jax.jvp(lambda x, c: nufft1d1_jvp(x, c, n_modes, eps=1e-10), (x, c), (dx, dc))
 
             # Finite difference approximation
             eps = 1e-7
@@ -1145,9 +1065,7 @@ class TestJVPFiniteDifference:
             ).astype(jnp.complex128)
 
             # Compute JVP with both tangents
-            primals, tangents = jax.jvp(
-                lambda x, f: nufft1d2_jvp(x, f, eps=1e-10), (x, f), (dx, df)
-            )
+            primals, tangents = jax.jvp(lambda x, f: nufft1d2_jvp(x, f, eps=1e-10), (x, f), (dx, df))
 
             # Finite difference approximation
             eps = 1e-7
@@ -1174,21 +1092,15 @@ class TestJVPFiniteDifference:
             n_modes = (n1, n2)
             key = jax.random.PRNGKey(42)
             x = jax.random.uniform(key, (M,), minval=-jnp.pi, maxval=jnp.pi).astype(jnp.float64)
-            y = jax.random.uniform(
-                jax.random.PRNGKey(43), (M,), minval=-jnp.pi, maxval=jnp.pi
-            ).astype(jnp.float64)
+            y = jax.random.uniform(jax.random.PRNGKey(43), (M,), minval=-jnp.pi, maxval=jnp.pi).astype(jnp.float64)
             c = (
-                jax.random.normal(jax.random.PRNGKey(44), (M,))
-                + 1j * jax.random.normal(jax.random.PRNGKey(45), (M,))
+                jax.random.normal(jax.random.PRNGKey(44), (M,)) + 1j * jax.random.normal(jax.random.PRNGKey(45), (M,))
             ).astype(jnp.complex128)
             dc = (
-                jax.random.normal(jax.random.PRNGKey(46), (M,))
-                + 1j * jax.random.normal(jax.random.PRNGKey(47), (M,))
+                jax.random.normal(jax.random.PRNGKey(46), (M,)) + 1j * jax.random.normal(jax.random.PRNGKey(47), (M,))
             ).astype(jnp.complex128)
 
-            primals, tangents = jax.jvp(
-                lambda c: nufft2d1_jvp(x, y, c, n_modes, eps=1e-10), (c,), (dc,)
-            )
+            primals, tangents = jax.jvp(lambda c: nufft2d1_jvp(x, y, c, n_modes, eps=1e-10), (c,), (dc,))
 
             eps = 1e-7
             f_plus = nufft2d1_jvp(x, y, c + eps * dc, n_modes, eps=1e-10)
@@ -1204,19 +1116,14 @@ class TestJVPFiniteDifference:
             n_modes = (n1, n2)
             key = jax.random.PRNGKey(42)
             x = jax.random.uniform(key, (M,), minval=-jnp.pi, maxval=jnp.pi).astype(jnp.float64)
-            y = jax.random.uniform(
-                jax.random.PRNGKey(43), (M,), minval=-jnp.pi, maxval=jnp.pi
-            ).astype(jnp.float64)
+            y = jax.random.uniform(jax.random.PRNGKey(43), (M,), minval=-jnp.pi, maxval=jnp.pi).astype(jnp.float64)
             c = (
-                jax.random.normal(jax.random.PRNGKey(44), (M,))
-                + 1j * jax.random.normal(jax.random.PRNGKey(45), (M,))
+                jax.random.normal(jax.random.PRNGKey(44), (M,)) + 1j * jax.random.normal(jax.random.PRNGKey(45), (M,))
             ).astype(jnp.complex128)
             dx = jax.random.normal(jax.random.PRNGKey(46), (M,)).astype(jnp.float64) * 0.1
             dy = jax.random.normal(jax.random.PRNGKey(47), (M,)).astype(jnp.float64) * 0.1
 
-            primals, tangents = jax.jvp(
-                lambda x, y: nufft2d1_jvp(x, y, c, n_modes, eps=1e-10), (x, y), (dx, dy)
-            )
+            primals, tangents = jax.jvp(lambda x, y: nufft2d1_jvp(x, y, c, n_modes, eps=1e-10), (x, y), (dx, dy))
 
             eps = 1e-7
             f_plus = nufft2d1_jvp(x + eps * dx, y + eps * dy, c, n_modes, eps=1e-10)
@@ -1235,9 +1142,7 @@ class TestJVPFiniteDifference:
             M, n1, n2 = 20, 10, 12
             key = jax.random.PRNGKey(42)
             x = jax.random.uniform(key, (M,), minval=-jnp.pi, maxval=jnp.pi).astype(jnp.float64)
-            y = jax.random.uniform(
-                jax.random.PRNGKey(43), (M,), minval=-jnp.pi, maxval=jnp.pi
-            ).astype(jnp.float64)
+            y = jax.random.uniform(jax.random.PRNGKey(43), (M,), minval=-jnp.pi, maxval=jnp.pi).astype(jnp.float64)
             f = (
                 jax.random.normal(jax.random.PRNGKey(44), (n2, n1))
                 + 1j * jax.random.normal(jax.random.PRNGKey(45), (n2, n1))
@@ -1262,9 +1167,7 @@ class TestJVPFiniteDifference:
             M, n1, n2 = 20, 10, 12
             key = jax.random.PRNGKey(42)
             x = jax.random.uniform(key, (M,), minval=-jnp.pi, maxval=jnp.pi).astype(jnp.float64)
-            y = jax.random.uniform(
-                jax.random.PRNGKey(43), (M,), minval=-jnp.pi, maxval=jnp.pi
-            ).astype(jnp.float64)
+            y = jax.random.uniform(jax.random.PRNGKey(43), (M,), minval=-jnp.pi, maxval=jnp.pi).astype(jnp.float64)
             f = (
                 jax.random.normal(jax.random.PRNGKey(44), (n2, n1))
                 + 1j * jax.random.normal(jax.random.PRNGKey(45), (n2, n1))
@@ -1272,9 +1175,7 @@ class TestJVPFiniteDifference:
             dx = jax.random.normal(jax.random.PRNGKey(46), (M,)).astype(jnp.float64) * 0.1
             dy = jax.random.normal(jax.random.PRNGKey(47), (M,)).astype(jnp.float64) * 0.1
 
-            primals, tangents = jax.jvp(
-                lambda x, y: nufft2d2_jvp(x, y, f, eps=1e-10), (x, y), (dx, dy)
-            )
+            primals, tangents = jax.jvp(lambda x, y: nufft2d2_jvp(x, y, f, eps=1e-10), (x, y), (dx, dy))
 
             eps = 1e-7
             c_plus = nufft2d2_jvp(x + eps * dx, y + eps * dy, f, eps=1e-10)
@@ -1294,24 +1195,16 @@ class TestJVPFiniteDifference:
             n_modes = (n1, n2, n3)
             key = jax.random.PRNGKey(42)
             x = jax.random.uniform(key, (M,), minval=-jnp.pi, maxval=jnp.pi).astype(jnp.float64)
-            y = jax.random.uniform(
-                jax.random.PRNGKey(43), (M,), minval=-jnp.pi, maxval=jnp.pi
-            ).astype(jnp.float64)
-            z = jax.random.uniform(
-                jax.random.PRNGKey(44), (M,), minval=-jnp.pi, maxval=jnp.pi
-            ).astype(jnp.float64)
+            y = jax.random.uniform(jax.random.PRNGKey(43), (M,), minval=-jnp.pi, maxval=jnp.pi).astype(jnp.float64)
+            z = jax.random.uniform(jax.random.PRNGKey(44), (M,), minval=-jnp.pi, maxval=jnp.pi).astype(jnp.float64)
             c = (
-                jax.random.normal(jax.random.PRNGKey(45), (M,))
-                + 1j * jax.random.normal(jax.random.PRNGKey(46), (M,))
+                jax.random.normal(jax.random.PRNGKey(45), (M,)) + 1j * jax.random.normal(jax.random.PRNGKey(46), (M,))
             ).astype(jnp.complex128)
             dc = (
-                jax.random.normal(jax.random.PRNGKey(47), (M,))
-                + 1j * jax.random.normal(jax.random.PRNGKey(48), (M,))
+                jax.random.normal(jax.random.PRNGKey(47), (M,)) + 1j * jax.random.normal(jax.random.PRNGKey(48), (M,))
             ).astype(jnp.complex128)
 
-            primals, tangents = jax.jvp(
-                lambda c: nufft3d1_jvp(x, y, z, c, n_modes, eps=1e-10), (c,), (dc,)
-            )
+            primals, tangents = jax.jvp(lambda c: nufft3d1_jvp(x, y, z, c, n_modes, eps=1e-10), (c,), (dc,))
 
             eps = 1e-7
             f_plus = nufft3d1_jvp(x, y, z, c + eps * dc, n_modes, eps=1e-10)
@@ -1327,15 +1220,10 @@ class TestJVPFiniteDifference:
             n_modes = (n1, n2, n3)
             key = jax.random.PRNGKey(42)
             x = jax.random.uniform(key, (M,), minval=-jnp.pi, maxval=jnp.pi).astype(jnp.float64)
-            y = jax.random.uniform(
-                jax.random.PRNGKey(43), (M,), minval=-jnp.pi, maxval=jnp.pi
-            ).astype(jnp.float64)
-            z = jax.random.uniform(
-                jax.random.PRNGKey(44), (M,), minval=-jnp.pi, maxval=jnp.pi
-            ).astype(jnp.float64)
+            y = jax.random.uniform(jax.random.PRNGKey(43), (M,), minval=-jnp.pi, maxval=jnp.pi).astype(jnp.float64)
+            z = jax.random.uniform(jax.random.PRNGKey(44), (M,), minval=-jnp.pi, maxval=jnp.pi).astype(jnp.float64)
             c = (
-                jax.random.normal(jax.random.PRNGKey(45), (M,))
-                + 1j * jax.random.normal(jax.random.PRNGKey(46), (M,))
+                jax.random.normal(jax.random.PRNGKey(45), (M,)) + 1j * jax.random.normal(jax.random.PRNGKey(46), (M,))
             ).astype(jnp.complex128)
             dx = jax.random.normal(jax.random.PRNGKey(47), (M,)).astype(jnp.float64) * 0.1
             dy = jax.random.normal(jax.random.PRNGKey(48), (M,)).astype(jnp.float64) * 0.1
@@ -1364,12 +1252,8 @@ class TestJVPFiniteDifference:
             M, n1, n2, n3 = 15, 6, 8, 7
             key = jax.random.PRNGKey(42)
             x = jax.random.uniform(key, (M,), minval=-jnp.pi, maxval=jnp.pi).astype(jnp.float64)
-            y = jax.random.uniform(
-                jax.random.PRNGKey(43), (M,), minval=-jnp.pi, maxval=jnp.pi
-            ).astype(jnp.float64)
-            z = jax.random.uniform(
-                jax.random.PRNGKey(44), (M,), minval=-jnp.pi, maxval=jnp.pi
-            ).astype(jnp.float64)
+            y = jax.random.uniform(jax.random.PRNGKey(43), (M,), minval=-jnp.pi, maxval=jnp.pi).astype(jnp.float64)
+            z = jax.random.uniform(jax.random.PRNGKey(44), (M,), minval=-jnp.pi, maxval=jnp.pi).astype(jnp.float64)
             f = (
                 jax.random.normal(jax.random.PRNGKey(45), (n3, n2, n1))
                 + 1j * jax.random.normal(jax.random.PRNGKey(46), (n3, n2, n1))
@@ -1394,12 +1278,8 @@ class TestJVPFiniteDifference:
             M, n1, n2, n3 = 15, 6, 8, 7
             key = jax.random.PRNGKey(42)
             x = jax.random.uniform(key, (M,), minval=-jnp.pi, maxval=jnp.pi).astype(jnp.float64)
-            y = jax.random.uniform(
-                jax.random.PRNGKey(43), (M,), minval=-jnp.pi, maxval=jnp.pi
-            ).astype(jnp.float64)
-            z = jax.random.uniform(
-                jax.random.PRNGKey(44), (M,), minval=-jnp.pi, maxval=jnp.pi
-            ).astype(jnp.float64)
+            y = jax.random.uniform(jax.random.PRNGKey(43), (M,), minval=-jnp.pi, maxval=jnp.pi).astype(jnp.float64)
+            z = jax.random.uniform(jax.random.PRNGKey(44), (M,), minval=-jnp.pi, maxval=jnp.pi).astype(jnp.float64)
             f = (
                 jax.random.normal(jax.random.PRNGKey(45), (n3, n2, n1))
                 + 1j * jax.random.normal(jax.random.PRNGKey(46), (n3, n2, n1))
@@ -1408,9 +1288,7 @@ class TestJVPFiniteDifference:
             dy = jax.random.normal(jax.random.PRNGKey(48), (M,)).astype(jnp.float64) * 0.1
             dz = jax.random.normal(jax.random.PRNGKey(49), (M,)).astype(jnp.float64) * 0.1
 
-            primals, tangents = jax.jvp(
-                lambda x, y, z: nufft3d2_jvp(x, y, z, f, eps=1e-10), (x, y, z), (dx, dy, dz)
-            )
+            primals, tangents = jax.jvp(lambda x, y, z: nufft3d2_jvp(x, y, z, f, eps=1e-10), (x, y, z), (dx, dy, dz))
 
             eps = 1e-7
             c_plus = nufft3d2_jvp(x + eps * dx, y + eps * dy, z + eps * dz, f, eps=1e-10)


### PR DESCRIPTION
 
### 1. **Removed hardcoded `@jax.jit` decorators** (15 occurrences)
   - Removed from all NUFFT type 1 functions: `nufft1d1`, `nufft2d1`, `nufft3d1`
   - Removed from all NUFFT type 2 functions: `nufft1d2`, `nufft2d2`, `nufft3d2`
   - Removed from all NUFFT type 3 functions: `nufft1d3`, `nufft2d3`, `nufft3d3`

### 2. **Improved custom VJP efficiency in autodiff.py**
   - Changed `@jax.custom_vjp` to use `nondiff_argnums` parameter
   - For 2D: `@partial(jax.custom_vjp, nondiff_argnums=(3, 4, 5))` for type 1 and `(3, 4)` for type 2
   - For 3D: `@partial(jax.custom_vjp, nondiff_argnums=(4, 5, 6))` for type 1 and `(4, 5)` for type 2
   - Reduced saved residuals in forward pass by only storing differentiable arguments
   - Updated backward pass signatures to receive non-differentiable args separately 

## Why Removing JIT is Reasonable

### 1. **User Control & Flexibility**
The hardcoded `@jax.jit` decorator forces JIT compilation at the function level, which removes control from library users. By removing it, users can:
- Apply `jax.jit` at higher levels in their own code where it makes more sense
- Selectively JIT specific computation graphs that include NUFFTs
- Control when and how compilation happens based on their use case

### 2. **Composition with Other JAX Transformations**
JAX users often need to compose multiple transformations (`jit`, `vmap`, `grad`, `pmap`, etc.). Having JIT baked into the library can cause issues:
- **Nested JIT problems**: JIT inside JIT can sometimes lead to unexpected behavior or compilation overhead (This is the problem that I currently met, I cannot jit a larger function that include nufftax's function inside).
- **Transform ordering**: Users may need `vmap(jit(...))` or `jit(vmap(...))` depending on their batching strategy 

### 3. **Performance Tuning**
Different applications have different optimal JIT boundaries:
- **Small batches**: Users might want to JIT the entire training loop
- **Large models**: Users might want finer-grained JIT control to manage compilation time
- **Interactive workflows**: During development, users may want to disable JIT entirely for faster iteration

### 4. **Standard JAX Library Practice**
Most modern JAX libraries (Flax, Optax, Equinox, etc.) don't hardcode `@jax.jit` into their core functions. They:
- Document that users should apply JIT where appropriate
- Provide examples of typical usage patterns
- Let the ecosystem handle optimization decisions

Users who want JIT can simply wrap calls in their own code:

```python
# User has full control:
jitted_nufft = jax.jit(nufftax.nufft2d1, static_argnames=("n_modes", "eps", "isign"))
# Or JIT a larger computation graph:
@jax.jit
def my_reconstruction(data, trajectory):
    return nufftax.nufft2d2(trajectory[0], trajectory[1], data)
```