### PR TITLE
feat: add primitive transpose rules for Pallas spread/interp kernels

### DIFF
--- a/nufftax/core/pallas_spread.py
+++ b/nufftax/core/pallas_spread.py
@@ -17,8 +17,35 @@ import functools
 
 import jax
 import jax.numpy as jnp
+from jax._src.core import Primitive, ShapedArray
+from jax._src.interpreters import ad as _ad
+from jax._src.interpreters import batching as _batching
 from jax.experimental import pallas as pl
 from jax.experimental.pallas import triton as pltriton
+
+from .spread import (
+    _HAS_PALLAS_GPU,
+    _PALLAS_MIN_M_INTERP,
+    _PALLAS_MIN_M_SPREAD,
+)
+from .spread import (
+    _spread_1d_dispatch as _s1_disp,
+)
+from .spread import (
+    _spread_2d_dispatch as _s2_disp,
+)
+from .spread import (
+    interp_1d_impl as _i1_impl,
+)
+from .spread import (
+    interp_2d_impl as _i2_impl,
+)
+from .spread import (
+    spread_1d_impl as _s1_impl,
+)
+from .spread import (
+    spread_2d_impl as _s2_impl,
+)
 
 
 BLOCK_SIZE = 256
@@ -373,18 +400,6 @@ def interp_2d_pallas(x, y, fw, kernel_params):
 # spread transposes to interp; interp transposes to spread.
 # Each primitive registers: impl, abstract_eval, transpose, jvp, batch.
 
-from jax._src.core import Primitive, ShapedArray
-from jax._src.interpreters import ad as _ad
-from jax._src.interpreters import batching as _batching
-
-from .kernel import compute_kernel_params as _kp_fn
-from .spread import (
-    _HAS_PALLAS_GPU, _PALLAS_MIN_M_SPREAD, _PALLAS_MIN_M_INTERP,
-    spread_1d_impl as _s1_impl, spread_2d_impl as _s2_impl,
-    interp_1d_impl as _i1_impl, interp_2d_impl as _i2_impl,
-    _spread_1d_dispatch as _s1_disp, _spread_2d_dispatch as _s2_disp,
-)
-
 
 def _gpu_dispatch(fn, *args):
     """Run fn(args) unless GPU is available with enough points."""
@@ -394,23 +409,34 @@ def _gpu_dispatch(fn, *args):
 # ===================================================================
 # 2D Spread  — spread(x, y, c) → grid(nf2, nf1)
 # ===================================================================
-_s2 = Primitive('nufftax_spread_2d')
+_s2 = Primitive("nufftax_spread_2d")
 _s2.multiple_results = False
-_s2.def_impl(lambda *a, nf1, nf2, kernel_params: (
-    spread_2d_pallas(a[0], a[1], a[2], nf1, nf2, kernel_params)
-    if _HAS_PALLAS_GPU and a[0].ndim > 0 and a[0].shape[0] >= _PALLAS_MIN_M_SPREAD
-    else _s2_impl(a[0], a[1], a[2], nf1, nf2, kernel_params)
-))
+_s2.def_impl(
+    lambda *a, nf1, nf2, kernel_params: (
+        spread_2d_pallas(a[0], a[1], a[2], nf1, nf2, kernel_params)
+        if _HAS_PALLAS_GPU and a[0].ndim > 0 and a[0].shape[0] >= _PALLAS_MIN_M_SPREAD
+        else _s2_impl(a[0], a[1], a[2], nf1, nf2, kernel_params)
+    )
+)
 _s2.def_abstract_eval(lambda *a, nf1, nf2, **_: ShapedArray((nf2, nf1), a[2].dtype))
 _ad.primitive_transposes[_s2] = lambda ct, *a, **p: (
-    jnp.zeros_like(a[0]), jnp.zeros_like(a[1]),
-    _i2_impl(a[0], a[1], ct, p['kernel_params']))
+    jnp.zeros_like(a[0]),
+    jnp.zeros_like(a[1]),
+    _i2_impl(a[0], a[1], ct, p["kernel_params"]),
+)
 _ad.primitive_jvps[_s2] = lambda pt, tt, nf1, nf2, kernel_params: (
     _s2.impl(*pt, nf1=nf1, nf2=nf2, kernel_params=kernel_params),
-    _s2.impl(*pt[:2], tt[2] if tt[2] is not None else jnp.zeros_like(pt[2]), nf1=nf1, nf2=nf2, kernel_params=kernel_params))
+    _s2.impl(
+        *pt[:2], tt[2] if tt[2] is not None else jnp.zeros_like(pt[2]), nf1=nf1, nf2=nf2, kernel_params=kernel_params
+    ),
+)
 _batching.primitive_batchers[_s2] = lambda a, ba, **p: (
     (jax.vmap(lambda d: _s2.bind(*a[:2], d, **p), 0, 0)(a[2]), ba[2])
-    if ba[2] is not None else (_s2.bind(*a, **p), ba[2]))
+    if ba[2] is not None
+    else (_s2.bind(*a, **p), ba[2])
+)
+
+
 def spread_2d_primitive(x, y, c, nf1, nf2, kp):
     return _s2.bind(x, y, c, nf1=nf1, nf2=nf2, kernel_params=kp)
 
@@ -418,23 +444,32 @@ def spread_2d_primitive(x, y, c, nf1, nf2, kp):
 # ===================================================================
 # 2D Interp — interp(x, y, fw) → points(M)
 # ===================================================================
-_i2 = Primitive('nufftax_interp_2d')
+_i2 = Primitive("nufftax_interp_2d")
 _i2.multiple_results = False
-_i2.def_impl(lambda *a, kernel_params: (
-    interp_2d_pallas(a[0], a[1], a[2], kernel_params)
-    if _HAS_PALLAS_GPU and a[0].ndim > 0 and a[0].shape[0] >= _PALLAS_MIN_M_INTERP
-    else _i2_impl(a[0], a[1], a[2], kernel_params)
-))
+_i2.def_impl(
+    lambda *a, kernel_params: (
+        interp_2d_pallas(a[0], a[1], a[2], kernel_params)
+        if _HAS_PALLAS_GPU and a[0].ndim > 0 and a[0].shape[0] >= _PALLAS_MIN_M_INTERP
+        else _i2_impl(a[0], a[1], a[2], kernel_params)
+    )
+)
 _i2.def_abstract_eval(lambda *a, **_: ShapedArray(a[0].shape, a[2].dtype))
 _ad.primitive_transposes[_i2] = lambda ct, *a, **p: (
-    jnp.zeros_like(a[0]), jnp.zeros_like(a[1]),
-    _s2_disp(a[0], a[1], ct, a[2].shape[-1], a[2].shape[-2], p['kernel_params']))
+    jnp.zeros_like(a[0]),
+    jnp.zeros_like(a[1]),
+    _s2_disp(a[0], a[1], ct, a[2].shape[-1], a[2].shape[-2], p["kernel_params"]),
+)
 _ad.primitive_jvps[_i2] = lambda pt, tt, kernel_params: (
     _i2.impl(*pt, kernel_params=kernel_params),
-    _i2.impl(*pt[:2], tt[2] if tt[2] is not None else jnp.zeros_like(pt[2]), kernel_params=kernel_params))
+    _i2.impl(*pt[:2], tt[2] if tt[2] is not None else jnp.zeros_like(pt[2]), kernel_params=kernel_params),
+)
 _batching.primitive_batchers[_i2] = lambda a, ba, **p: (
     (jax.vmap(lambda d: _i2.bind(*a[:2], d, **p), 0, 0)(a[2]), ba[2])
-    if ba[2] is not None else (_i2.bind(*a, **p), ba[2]))
+    if ba[2] is not None
+    else (_i2.bind(*a, **p), ba[2])
+)
+
+
 def interp_2d_primitive(x, y, fw, kp):
     return _i2.bind(x, y, fw, kernel_params=kp)
 
@@ -442,21 +477,28 @@ def interp_2d_primitive(x, y, fw, kp):
 # ===================================================================
 # 1D Spread  — spread(x, c) → grid(nf)
 # ===================================================================
-_s1 = Primitive('nufftax_spread_1d')
+_s1 = Primitive("nufftax_spread_1d")
 _s1.multiple_results = False
-_s1.def_impl(lambda *a, nf, kernel_params: (
-    spread_1d_pallas(a[0], a[1], nf, kernel_params)
-    if _HAS_PALLAS_GPU and a[0].ndim > 0 and a[0].shape[0] >= _PALLAS_MIN_M_SPREAD
-    else _s1_impl(a[0], a[1], nf, kernel_params)
-))
+_s1.def_impl(
+    lambda *a, nf, kernel_params: (
+        spread_1d_pallas(a[0], a[1], nf, kernel_params)
+        if _HAS_PALLAS_GPU and a[0].ndim > 0 and a[0].shape[0] >= _PALLAS_MIN_M_SPREAD
+        else _s1_impl(a[0], a[1], nf, kernel_params)
+    )
+)
 _s1.def_abstract_eval(lambda *a, nf, **_: ShapedArray((nf,), a[1].dtype))
-_ad.primitive_transposes[_s1] = lambda ct, *a, **p: (jnp.zeros_like(a[0]), _i1_impl(a[0], ct, p['kernel_params']))
+_ad.primitive_transposes[_s1] = lambda ct, *a, **p: (jnp.zeros_like(a[0]), _i1_impl(a[0], ct, p["kernel_params"]))
 _ad.primitive_jvps[_s1] = lambda pt, tt, nf, kernel_params: (
     _s1.impl(*pt, nf=nf, kernel_params=kernel_params),
-    _s1.impl(pt[0], tt[1] if tt[1] is not None else jnp.zeros_like(pt[1]), nf=nf, kernel_params=kernel_params))
+    _s1.impl(pt[0], tt[1] if tt[1] is not None else jnp.zeros_like(pt[1]), nf=nf, kernel_params=kernel_params),
+)
 _batching.primitive_batchers[_s1] = lambda a, ba, **p: (
     (jax.vmap(lambda d: _s1.bind(a[0], d, **p), 0, 0)(a[1]), ba[1])
-    if ba[1] is not None else (_s1.bind(*a, **p), ba[1]))
+    if ba[1] is not None
+    else (_s1.bind(*a, **p), ba[1])
+)
+
+
 def spread_1d_primitive(x, c, nf, kp):
     return _s1.bind(x, c, nf=nf, kernel_params=kp)
 
@@ -464,22 +506,30 @@ def spread_1d_primitive(x, c, nf, kp):
 # ===================================================================
 # 1D Interp — interp(x, fw) → points(M)
 # ===================================================================
-_i1 = Primitive('nufftax_interp_1d')
+_i1 = Primitive("nufftax_interp_1d")
 _i1.multiple_results = False
-_i1.def_impl(lambda *a, kernel_params: (
-    interp_1d_pallas(a[0], a[1], kernel_params)
-    if _HAS_PALLAS_GPU and a[0].ndim > 0 and a[0].shape[0] >= _PALLAS_MIN_M_INTERP
-    else _i1_impl(a[0], a[1], kernel_params)
-))
+_i1.def_impl(
+    lambda *a, kernel_params: (
+        interp_1d_pallas(a[0], a[1], kernel_params)
+        if _HAS_PALLAS_GPU and a[0].ndim > 0 and a[0].shape[0] >= _PALLAS_MIN_M_INTERP
+        else _i1_impl(a[0], a[1], kernel_params)
+    )
+)
 _i1.def_abstract_eval(lambda *a, **_: ShapedArray(a[0].shape, a[1].dtype))
 _ad.primitive_transposes[_i1] = lambda ct, *a, **p: (
     jnp.zeros_like(a[0]),
-    _s1_disp(a[0], ct, nf=a[1].shape[-1], kernel_params=p['kernel_params']))
+    _s1_disp(a[0], ct, nf=a[1].shape[-1], kernel_params=p["kernel_params"]),
+)
 _ad.primitive_jvps[_i1] = lambda pt, tt, kernel_params: (
     _i1.impl(*pt, kernel_params=kernel_params),
-    _i1.impl(pt[0], tt[1] if tt[1] is not None else jnp.zeros_like(pt[1]), kernel_params=kernel_params))
+    _i1.impl(pt[0], tt[1] if tt[1] is not None else jnp.zeros_like(pt[1]), kernel_params=kernel_params),
+)
 _batching.primitive_batchers[_i1] = lambda a, ba, **p: (
     (jax.vmap(lambda d: _i1.bind(a[0], d, **p), 0, 0)(a[1]), ba[1])
-    if ba[1] is not None else (_i1.bind(*a, **p), ba[1]))
+    if ba[1] is not None
+    else (_i1.bind(*a, **p), ba[1])
+)
+
+
 def interp_1d_primitive(x, fw, kp):
     return _i1.bind(x, fw, kernel_params=kp)

--- a/nufftax/core/pallas_spread.py
+++ b/nufftax/core/pallas_spread.py
@@ -364,3 +364,122 @@ def interp_2d_pallas(x, y, fw, kernel_params):
         compiler_params=pltriton.CompilerParams(num_warps=4, num_stages=2),
     )(x_pad, y_pad, fw_real, fw_imag)
     return (c_real[:M] + 1j * c_imag[:M]).astype(fw.dtype)
+
+
+# ============================================================================
+# ============================================================================
+# Custom JAX Primitives with transpose rules for Pallas operations
+# ============================================================================
+# spread transposes to interp; interp transposes to spread.
+# Each primitive registers: impl, abstract_eval, transpose, jvp, batch.
+
+from jax._src.core import Primitive, ShapedArray
+from jax._src.interpreters import ad as _ad
+from jax._src.interpreters import batching as _batching
+
+from .kernel import compute_kernel_params as _kp_fn
+from .spread import (
+    _HAS_PALLAS_GPU, _PALLAS_MIN_M_SPREAD, _PALLAS_MIN_M_INTERP,
+    spread_1d_impl as _s1_impl, spread_2d_impl as _s2_impl,
+    interp_1d_impl as _i1_impl, interp_2d_impl as _i2_impl,
+    _spread_1d_dispatch as _s1_disp, _spread_2d_dispatch as _s2_disp,
+)
+
+
+def _gpu_dispatch(fn, *args):
+    """Run fn(args) unless GPU is available with enough points."""
+    return fn(*args)
+
+
+# ===================================================================
+# 2D Spread  — spread(x, y, c) → grid(nf2, nf1)
+# ===================================================================
+_s2 = Primitive('nufftax_spread_2d')
+_s2.multiple_results = False
+_s2.def_impl(lambda *a, nf1, nf2, kernel_params: (
+    spread_2d_pallas(a[0], a[1], a[2], nf1, nf2, kernel_params)
+    if _HAS_PALLAS_GPU and a[0].ndim > 0 and a[0].shape[0] >= _PALLAS_MIN_M_SPREAD
+    else _s2_impl(a[0], a[1], a[2], nf1, nf2, kernel_params)
+))
+_s2.def_abstract_eval(lambda *a, nf1, nf2, **_: ShapedArray((nf2, nf1), a[2].dtype))
+_ad.primitive_transposes[_s2] = lambda ct, *a, **p: (
+    jnp.zeros_like(a[0]), jnp.zeros_like(a[1]),
+    _i2_impl(a[0], a[1], ct, p['kernel_params']))
+_ad.primitive_jvps[_s2] = lambda pt, tt, nf1, nf2, kernel_params: (
+    _s2.impl(*pt, nf1=nf1, nf2=nf2, kernel_params=kernel_params),
+    _s2.impl(*pt[:2], tt[2] if tt[2] is not None else jnp.zeros_like(pt[2]), nf1=nf1, nf2=nf2, kernel_params=kernel_params))
+_batching.primitive_batchers[_s2] = lambda a, ba, **p: (
+    (jax.vmap(lambda d: _s2.bind(*a[:2], d, **p), 0, 0)(a[2]), ba[2])
+    if ba[2] is not None else (_s2.bind(*a, **p), ba[2]))
+def spread_2d_primitive(x, y, c, nf1, nf2, kp):
+    return _s2.bind(x, y, c, nf1=nf1, nf2=nf2, kernel_params=kp)
+
+
+# ===================================================================
+# 2D Interp — interp(x, y, fw) → points(M)
+# ===================================================================
+_i2 = Primitive('nufftax_interp_2d')
+_i2.multiple_results = False
+_i2.def_impl(lambda *a, kernel_params: (
+    interp_2d_pallas(a[0], a[1], a[2], kernel_params)
+    if _HAS_PALLAS_GPU and a[0].ndim > 0 and a[0].shape[0] >= _PALLAS_MIN_M_INTERP
+    else _i2_impl(a[0], a[1], a[2], kernel_params)
+))
+_i2.def_abstract_eval(lambda *a, **_: ShapedArray(a[0].shape, a[2].dtype))
+_ad.primitive_transposes[_i2] = lambda ct, *a, **p: (
+    jnp.zeros_like(a[0]), jnp.zeros_like(a[1]),
+    _s2_disp(a[0], a[1], ct, a[2].shape[-1], a[2].shape[-2], p['kernel_params']))
+_ad.primitive_jvps[_i2] = lambda pt, tt, kernel_params: (
+    _i2.impl(*pt, kernel_params=kernel_params),
+    _i2.impl(*pt[:2], tt[2] if tt[2] is not None else jnp.zeros_like(pt[2]), kernel_params=kernel_params))
+_batching.primitive_batchers[_i2] = lambda a, ba, **p: (
+    (jax.vmap(lambda d: _i2.bind(*a[:2], d, **p), 0, 0)(a[2]), ba[2])
+    if ba[2] is not None else (_i2.bind(*a, **p), ba[2]))
+def interp_2d_primitive(x, y, fw, kp):
+    return _i2.bind(x, y, fw, kernel_params=kp)
+
+
+# ===================================================================
+# 1D Spread  — spread(x, c) → grid(nf)
+# ===================================================================
+_s1 = Primitive('nufftax_spread_1d')
+_s1.multiple_results = False
+_s1.def_impl(lambda *a, nf, kernel_params: (
+    spread_1d_pallas(a[0], a[1], nf, kernel_params)
+    if _HAS_PALLAS_GPU and a[0].ndim > 0 and a[0].shape[0] >= _PALLAS_MIN_M_SPREAD
+    else _s1_impl(a[0], a[1], nf, kernel_params)
+))
+_s1.def_abstract_eval(lambda *a, nf, **_: ShapedArray((nf,), a[1].dtype))
+_ad.primitive_transposes[_s1] = lambda ct, *a, **p: (jnp.zeros_like(a[0]), _i1_impl(a[0], ct, p['kernel_params']))
+_ad.primitive_jvps[_s1] = lambda pt, tt, nf, kernel_params: (
+    _s1.impl(*pt, nf=nf, kernel_params=kernel_params),
+    _s1.impl(pt[0], tt[1] if tt[1] is not None else jnp.zeros_like(pt[1]), nf=nf, kernel_params=kernel_params))
+_batching.primitive_batchers[_s1] = lambda a, ba, **p: (
+    (jax.vmap(lambda d: _s1.bind(a[0], d, **p), 0, 0)(a[1]), ba[1])
+    if ba[1] is not None else (_s1.bind(*a, **p), ba[1]))
+def spread_1d_primitive(x, c, nf, kp):
+    return _s1.bind(x, c, nf=nf, kernel_params=kp)
+
+
+# ===================================================================
+# 1D Interp — interp(x, fw) → points(M)
+# ===================================================================
+_i1 = Primitive('nufftax_interp_1d')
+_i1.multiple_results = False
+_i1.def_impl(lambda *a, kernel_params: (
+    interp_1d_pallas(a[0], a[1], kernel_params)
+    if _HAS_PALLAS_GPU and a[0].ndim > 0 and a[0].shape[0] >= _PALLAS_MIN_M_INTERP
+    else _i1_impl(a[0], a[1], kernel_params)
+))
+_i1.def_abstract_eval(lambda *a, **_: ShapedArray(a[0].shape, a[1].dtype))
+_ad.primitive_transposes[_i1] = lambda ct, *a, **p: (
+    jnp.zeros_like(a[0]),
+    _s1_disp(a[0], ct, nf=a[1].shape[-1], kernel_params=p['kernel_params']))
+_ad.primitive_jvps[_i1] = lambda pt, tt, kernel_params: (
+    _i1.impl(*pt, kernel_params=kernel_params),
+    _i1.impl(pt[0], tt[1] if tt[1] is not None else jnp.zeros_like(pt[1]), kernel_params=kernel_params))
+_batching.primitive_batchers[_i1] = lambda a, ba, **p: (
+    (jax.vmap(lambda d: _i1.bind(a[0], d, **p), 0, 0)(a[1]), ba[1])
+    if ba[1] is not None else (_i1.bind(*a, **p), ba[1]))
+def interp_1d_primitive(x, fw, kp):
+    return _i1.bind(x, fw, kernel_params=kp)

--- a/nufftax/core/spread.py
+++ b/nufftax/core/spread.py
@@ -676,40 +676,42 @@ def interp_3d_impl(
 
 
 def _spread_1d_dispatch(x, c, nf, kernel_params):
-    """Dispatch 1D spreading to Pallas GPU or pure JAX."""
-    if _HAS_PALLAS_GPU and x.shape[0] >= _PALLAS_MIN_M_SPREAD:
+    """Dispatch 1D spreading to Pallas GPU or pure JAX (via primitive with transpose)."""
+    from .pallas_spread import spread_1d_primitive
+    if _HAS_PALLAS_GPU and x.ndim > 0 and x.shape[0] >= _PALLAS_MIN_M_SPREAD:
         if c.ndim == 1:
-            return spread_1d_pallas(x, c, nf, kernel_params)
-        return jax.vmap(lambda ci: spread_1d_pallas(x, ci, nf, kernel_params))(c)
+            return spread_1d_primitive(x, c, nf, kernel_params)
+        return jax.vmap(lambda ci: spread_1d_primitive(x, ci, nf, kernel_params))(c)
     return spread_1d_impl(x, c, nf, kernel_params)
 
 
 def _spread_2d_dispatch(x, y, c, nf1, nf2, kernel_params):
-    """Dispatch 2D spreading to Pallas GPU or pure JAX."""
-    if _HAS_PALLAS_GPU and x.shape[0] >= _PALLAS_MIN_M_SPREAD:
+    """Dispatch 2D spreading to Pallas GPU or pure JAX (via primitive with transpose)."""
+    from .pallas_spread import spread_2d_primitive
+    if _HAS_PALLAS_GPU and x.ndim > 0 and x.shape[0] >= _PALLAS_MIN_M_SPREAD:
         if c.ndim == 1:
-            return spread_2d_pallas(x, y, c, nf1, nf2, kernel_params)
-        return jax.vmap(lambda ci: spread_2d_pallas(x, y, ci, nf1, nf2, kernel_params))(c)
+            return spread_2d_primitive(x, y, c, nf1, nf2, kernel_params)
+        return jax.vmap(lambda ci: spread_2d_primitive(x, y, ci, nf1, nf2, kernel_params))(c)
     return spread_2d_impl(x, y, c, nf1, nf2, kernel_params)
 
 
 def _interp_1d_dispatch(x, fw, kernel_params):
-    """Dispatch 1D interpolation to Pallas GPU or pure JAX."""
-    M = x.shape[0]
-    if _HAS_PALLAS_GPU and M >= _PALLAS_MIN_M_INTERP:
+    """Dispatch 1D interpolation to Pallas GPU or pure JAX (via primitive with transpose)."""
+    from .pallas_spread import interp_1d_primitive
+    if _HAS_PALLAS_GPU and x.ndim > 0 and x.shape[0] >= _PALLAS_MIN_M_INTERP:
         if fw.ndim == 1:
-            return interp_1d_pallas(x, fw, kernel_params)
-        return jax.vmap(lambda fwi: interp_1d_pallas(x, fwi, kernel_params))(fw)
+            return interp_1d_primitive(x, fw, kernel_params)
+        return jax.vmap(lambda fwi: interp_1d_primitive(x, fwi, kernel_params))(fw)
     return interp_1d_impl(x, fw, kernel_params)
 
 
 def _interp_2d_dispatch(x, y, fw, kernel_params):
-    """Dispatch 2D interpolation to Pallas GPU or pure JAX."""
-    M = x.shape[0]
-    if _HAS_PALLAS_GPU and M >= _PALLAS_MIN_M_INTERP:
+    """Dispatch 2D interpolation to Pallas GPU or pure JAX (via primitive with transpose)."""
+    from .pallas_spread import interp_2d_primitive
+    if _HAS_PALLAS_GPU and x.ndim > 0 and x.shape[0] >= _PALLAS_MIN_M_INTERP:
         if fw.ndim == 2:
-            return interp_2d_pallas(x, y, fw, kernel_params)
-        return jax.vmap(lambda fwi: interp_2d_pallas(x, y, fwi, kernel_params))(fw)
+            return interp_2d_primitive(x, y, fw, kernel_params)
+        return jax.vmap(lambda fwi: interp_2d_primitive(x, y, fwi, kernel_params))(fw)
     return interp_2d_impl(x, y, fw, kernel_params)
 
 

--- a/nufftax/core/spread.py
+++ b/nufftax/core/spread.py
@@ -24,12 +24,7 @@ from .kernel import KernelParams, es_kernel, es_kernel_with_derivative
 
 _HAS_PALLAS_GPU = False
 try:
-    from .pallas_spread import (
-        interp_1d_pallas,
-        interp_2d_pallas,
-        spread_1d_pallas,
-        spread_2d_pallas,
-    )
+    from . import pallas_spread as _  # noqa: F401 — check Pallas availability
 
     _HAS_PALLAS_GPU = any(d.platform == "gpu" for d in jax.devices())
 except ImportError:
@@ -678,6 +673,7 @@ def interp_3d_impl(
 def _spread_1d_dispatch(x, c, nf, kernel_params):
     """Dispatch 1D spreading to Pallas GPU or pure JAX (via primitive with transpose)."""
     from .pallas_spread import spread_1d_primitive
+
     if _HAS_PALLAS_GPU and x.ndim > 0 and x.shape[0] >= _PALLAS_MIN_M_SPREAD:
         if c.ndim == 1:
             return spread_1d_primitive(x, c, nf, kernel_params)
@@ -688,6 +684,7 @@ def _spread_1d_dispatch(x, c, nf, kernel_params):
 def _spread_2d_dispatch(x, y, c, nf1, nf2, kernel_params):
     """Dispatch 2D spreading to Pallas GPU or pure JAX (via primitive with transpose)."""
     from .pallas_spread import spread_2d_primitive
+
     if _HAS_PALLAS_GPU and x.ndim > 0 and x.shape[0] >= _PALLAS_MIN_M_SPREAD:
         if c.ndim == 1:
             return spread_2d_primitive(x, y, c, nf1, nf2, kernel_params)
@@ -698,6 +695,7 @@ def _spread_2d_dispatch(x, y, c, nf1, nf2, kernel_params):
 def _interp_1d_dispatch(x, fw, kernel_params):
     """Dispatch 1D interpolation to Pallas GPU or pure JAX (via primitive with transpose)."""
     from .pallas_spread import interp_1d_primitive
+
     if _HAS_PALLAS_GPU and x.ndim > 0 and x.shape[0] >= _PALLAS_MIN_M_INTERP:
         if fw.ndim == 1:
             return interp_1d_primitive(x, fw, kernel_params)
@@ -708,6 +706,7 @@ def _interp_1d_dispatch(x, fw, kernel_params):
 def _interp_2d_dispatch(x, y, fw, kernel_params):
     """Dispatch 2D interpolation to Pallas GPU or pure JAX (via primitive with transpose)."""
     from .pallas_spread import interp_2d_primitive
+
     if _HAS_PALLAS_GPU and x.ndim > 0 and x.shape[0] >= _PALLAS_MIN_M_INTERP:
         if fw.ndim == 2:
             return interp_2d_primitive(x, y, fw, kernel_params)

--- a/nufftax/transforms/nufft1.py
+++ b/nufftax/transforms/nufft1.py
@@ -14,7 +14,7 @@ import jax.numpy as jnp
 
 from ..core.deconvolve import deconvolve_shuffle_1d, deconvolve_shuffle_2d, deconvolve_shuffle_3d
 from ..core.kernel import compute_kernel_params, kernel_fourier_series
-from ..core.spread import spread_1d, spread_2d, spread_3d
+from ..core.spread import _spread_1d_dispatch, _spread_2d_dispatch, spread_3d_impl
 from ..utils.grid import compute_grid_size
 
 
@@ -72,7 +72,7 @@ def nufft1d1(
 
     # Step 2: Spread to fine grid
     # The spread function expects coordinates in [-pi, pi)
-    fw = spread_1d(x_normalized, c, nf, kernel_params)
+    fw = _spread_1d_dispatch(x_normalized, c, nf, kernel_params)
 
     # Step 3: FFT
     # Sign convention: isign > 0 means exp(+ikx), which requires IFFT * nf
@@ -148,7 +148,7 @@ def nufft2d1(
     y_normalized = jnp.mod(y + jnp.pi, 2.0 * jnp.pi) - jnp.pi
 
     # Spread to fine grid
-    fw = spread_2d(x_normalized, y_normalized, c, nf1, nf2, kernel_params)
+    fw = _spread_2d_dispatch(x_normalized, y_normalized, c, nf1, nf2, kernel_params)
 
     # 2D FFT - sign convention same as 1D
     fw_hat = jnp.fft.ifft2(fw, axes=(-2, -1)) * (nf1 * nf2) if isign > 0 else jnp.fft.fft2(fw, axes=(-2, -1))
@@ -226,7 +226,7 @@ def nufft3d1(
     z_normalized = jnp.mod(z + jnp.pi, 2.0 * jnp.pi) - jnp.pi
 
     # Spread to fine grid
-    fw = spread_3d(x_normalized, y_normalized, z_normalized, c, nf1, nf2, nf3, kernel_params)
+    fw = spread_3d_impl(x_normalized, y_normalized, z_normalized, c, nf1, nf2, nf3, kernel_params)
 
     # 3D FFT - sign convention same as 1D
     if isign > 0:

--- a/nufftax/transforms/nufft2.py
+++ b/nufftax/transforms/nufft2.py
@@ -14,7 +14,7 @@ import jax.numpy as jnp
 
 from ..core.deconvolve import deconvolve_pad_1d, deconvolve_pad_2d, deconvolve_pad_3d
 from ..core.kernel import compute_kernel_params, kernel_fourier_series
-from ..core.spread import interp_1d, interp_2d, interp_3d
+from ..core.spread import _interp_1d_dispatch, _interp_2d_dispatch, interp_3d_impl
 from ..utils.grid import compute_grid_size
 
 
@@ -74,7 +74,7 @@ def nufft1d2(
     x_normalized = jnp.mod(x + jnp.pi, 2.0 * jnp.pi) - jnp.pi
 
     # Step 4: Interpolate to nonuniform points
-    c = interp_1d(x_normalized, fw, nf, kernel_params)
+    c = _interp_1d_dispatch(x_normalized, fw, kernel_params)
 
     if not batched:
         c = c[0]
@@ -138,7 +138,7 @@ def nufft2d2(
     y_normalized = jnp.mod(y + jnp.pi, 2.0 * jnp.pi) - jnp.pi
 
     # Step 4: Interpolate to nonuniform points
-    c = interp_2d(x_normalized, y_normalized, fw, nf1, nf2, kernel_params)
+    c = _interp_2d_dispatch(x_normalized, y_normalized, fw, kernel_params)
 
     if not batched:
         c = c[0]
@@ -210,7 +210,7 @@ def nufft3d2(
     z_normalized = jnp.mod(z + jnp.pi, 2.0 * jnp.pi) - jnp.pi
 
     # Step 4: Interpolate to nonuniform points
-    c = interp_3d(x_normalized, y_normalized, z_normalized, fw, nf1, nf2, nf3, kernel_params)
+    c = interp_3d_impl(x_normalized, y_normalized, z_normalized, fw, kernel_params)
 
     if not batched:
         c = c[0]

--- a/nufftax/transforms/nufft3.py
+++ b/nufftax/transforms/nufft3.py
@@ -27,7 +27,7 @@ import jax.numpy as jnp
 import numpy as np
 
 from ..core.kernel import compute_kernel_params, es_kernel
-from ..core.spread import spread_1d, spread_2d, spread_3d
+from ..core.spread import _spread_1d_dispatch, _spread_2d_dispatch, spread_3d_impl
 from ..utils.grid import next_smooth_int
 from .nufft2 import nufft1d2, nufft2d2, nufft3d2
 
@@ -280,7 +280,7 @@ def nufft1d3(
     c_phased = c * prephase[None, :]
 
     # Spread to fine grid (spatial representation)
-    fw = spread_1d(x_normalized, c_phased, nf, kernel_params)
+    fw = _spread_1d_dispatch(x_normalized, c_phased, nf, kernel_params)
 
     # Rescale target frequencies: s' = h * gamma * (s - D)
     s_rescaled = h * gamma * (s - D)
@@ -375,7 +375,7 @@ def nufft2d3(
     c_phased = c * prephase[None, :]
 
     # Spread
-    fw = spread_2d(x_normalized, y_normalized, c_phased, nf1, nf2, kernel_params)
+    fw = _spread_2d_dispatch(x_normalized, y_normalized, c_phased, nf1, nf2, kernel_params)
 
     # Rescale target frequencies
     s_rescaled = h1 * gamma1 * (s - Ds)
@@ -480,7 +480,7 @@ def nufft3d3(
     c_phased = c * prephase[None, :]
 
     # Spread
-    fw = spread_3d(x_normalized, y_normalized, z_normalized, c_phased, nf1, nf2, nf3, kernel_params)
+    fw = spread_3d_impl(x_normalized, y_normalized, z_normalized, c_phased, nf1, nf2, nf3, kernel_params)
 
     # Rescale target frequencies
     s_rescaled = h1 * gamma1 * (s - Ds)


### PR DESCRIPTION
- Add jax.core.Primitive wrappers for 1D/2D spread and interp
- Register transpose rules: spread ↔ interp (for linear adjoint)
- Register impl, abstract_eval, jvp, batch rules
- Update nufft1.py/nufft2.py/nufft3.py to use dispatch functions 