### PR TITLE
Support Python 3.11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.12", "3.13"]
+        python-version: ["3.11", "3.12", "3.13"]
 
     steps:
       - uses: actions/checkout@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ version = "0.5.0"
 description = "Pure JAX implementation of Non-Uniform FFT"
 readme = "README.md"
 license = "MIT"
-requires-python = ">=3.12"
+requires-python = ">=3.11"
 authors = [
     {name = "Gragas", email = "contact@gragas.ai"},
     {name = "Geoffroy Oudoumanessah"},
@@ -19,6 +19,7 @@ classifiers = [
     "Development Status :: 3 - Alpha",
     "Intended Audience :: Science/Research",
     "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Topic :: Scientific/Engineering :: Mathematics",
@@ -74,7 +75,7 @@ filterwarnings = [
 ]
 
 [tool.ruff]
-target-version = "py312"
+target-version = "py311"
 line-length = 119
 
 [tool.ruff.lint]


### PR DESCRIPTION
Closes #8.

Lower minimum Python from 3.12 to 3.11. The code only uses 3.10+ syntax, so the `>=3.12` pin was unnecessary.

- `requires-python = ">=3.11"` + 3.11 classifier
- ruff `target-version = py311`
- add 3.11 to CI matrix

Tested: full suite green on Python 3.11 — CPU (215 passed, 4 GPU-only skipped) and A100 GPU (219 passed, incl. Pallas 3D).