### PR TITLE
Support custom spreading/interpolation kernels

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,11 @@ jobs:
       - name: Run tests
         run: uv run pytest tests/ -v --tb=short
 
+      - name: Run Pallas kernel tests (interpret mode, CPU)
+        run: uv run pytest tests/test_pallas_interpret.py -v --tb=short
+        env:
+          NUFFTAX_PALLAS_INTERPRET: "1"
+
   build:
     runs-on: ubuntu-latest
     needs: test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,7 @@ jobs:
       - name: Run Pallas kernel tests (interpret mode, CPU)
         run: uv run pytest tests/test_pallas_interpret.py -v --tb=short
         env:
+          NUFFTAX_PALLAS_BACKEND: "1"
           NUFFTAX_PALLAS_INTERPRET: "1"
 
   build:

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -295,6 +295,12 @@ All transform functions share these parameters:
    * - ``isign``
      - ``int``
      - Sign of the exponent: ``+1`` or ``-1``. Default varies by transform type.
+   * - ``upsampfac``
+     - ``float`` or ``tuple``
+     - Oversampling factor of the internal fine grid (default ``2.0``); ``1.25``
+       is faster but coarser. Accepted by all Type 1/2/3 transforms. For Type 1/2,
+       a ``(forward, backward)`` pair sets the forward transform and its adjoint
+       (used in reverse-mode AD) independently.
 
 Return Values
 ~~~~~~~~~~~~~

--- a/docs/concepts.rst
+++ b/docs/concepts.rst
@@ -296,7 +296,7 @@ the point coordinates (which use the kernel derivative).
 
 .. note::
 
-   **GPU.** When the Pallas backend is enabled (the default; see
+   **GPU.** When the Pallas backend is enabled (opt-in; see
    ``NUFFTAX_PALLAS_BACKEND`` below), custom kernels run through the same fused
    Pallas spreading kernels as the ES kernel — ``phi`` is threaded into the
    Triton kernel as a static closure — so there is no performance penalty beyond
@@ -306,10 +306,11 @@ the point coordinates (which use the kernel derivative).
 
 .. note::
 
-   **Selecting the backend.** GPU spreading uses the fused Pallas kernels by
-   default. Set ``NUFFTAX_PALLAS_BACKEND=0`` to force the pure-JAX path
-   everywhere — slower for large problems, but more robust across JAX versions
-   and GPU backends. On CPU the pure-JAX path is always used.
+   **Selecting the backend.** The fused Pallas GPU spreading kernels are
+   opt-in: set ``NUFFTAX_PALLAS_BACKEND=1`` to enable them (much faster
+   spreading for large problems on GPU). By default the pure-JAX path is used
+   everywhere — more robust across JAX versions and GPU backends. On CPU the
+   pure-JAX path is always used.
 
 .. note::
 

--- a/docs/concepts.rst
+++ b/docs/concepts.rst
@@ -274,12 +274,20 @@ the point coordinates (which use the kernel derivative).
 
 .. note::
 
-   **GPU.** Custom kernels run through the same fused Pallas spreading kernels
-   as the ES kernel — ``phi`` is threaded into the Triton kernel as a static
-   closure — so there is no performance penalty beyond the cost of ``phi``
-   itself. This requires ``phi`` to be pure ``jnp`` arithmetic (no Python
-   control flow on traced values) and passed as a static argument; a distinct
-   kernel triggers one Pallas recompilation.
+   **GPU.** When the Pallas backend is enabled (the default; see
+   ``NUFFTAX_PALLAS_BACKEND`` below), custom kernels run through the same fused
+   Pallas spreading kernels as the ES kernel — ``phi`` is threaded into the
+   Triton kernel as a static closure — so there is no performance penalty beyond
+   the cost of ``phi`` itself. This requires ``phi`` to be pure ``jnp``
+   arithmetic (no Python control flow on traced values) and passed as a static
+   argument; a distinct kernel triggers one Pallas recompilation.
+
+.. note::
+
+   **Selecting the backend.** GPU spreading uses the fused Pallas kernels by
+   default. Set ``NUFFTAX_PALLAS_BACKEND=0`` to force the pure-JAX path
+   everywhere — slower for large problems, but more robust across JAX versions
+   and GPU backends. On CPU the pure-JAX path is always used.
 
 .. note::
 

--- a/docs/concepts.rst
+++ b/docs/concepts.rst
@@ -227,6 +227,81 @@ For gradients w.r.t. the point locations ``x``, the kernel derivative is used.
 
    grad_x = jax.grad(loss_positions)(x)
 
+Custom Spreading Kernels
+------------------------
+
+The spreading and interpolation primitives are exposed directly, so you can use
+them on their own — without the full NUFFT pipeline — and with **your own
+kernel** instead of the built-in ES kernel. A typical use case is spreading
+short-range Gaussians (or any localized bump) onto a grid.
+
+The primitives live in ``nufftax.core``:
+
+- ``spread_1d/2d/3d`` — scatter point values onto a grid:
+  :math:`\text{fw}[k] = \sum_j c_j\, \phi(k - \tilde{x}_j)`
+- ``interp_1d/2d/3d`` — the adjoint gather:
+  :math:`c_j = \sum_k \text{fw}[k]\, \phi(k - \tilde{x}_j)`
+
+where :math:`\tilde{x}_j` is the point mapped to grid units and :math:`\phi` is
+the kernel, nonzero only over ``nspread`` neighbouring grid points.
+
+By default they take the ES kernel via ``compute_kernel_params``:
+
+.. code-block:: python
+
+   from nufftax.core import spread_1d, compute_kernel_params
+
+   kp = compute_kernel_params(1e-6)            # ES kernel (tol=1e-6)
+   fw = spread_1d(x, c, 256, kp)               # (x, c, nf, kernel)
+
+To use a custom kernel, pass a ``Kernel`` instead. A truncated Gaussian is
+provided out of the box:
+
+.. code-block:: python
+
+   from nufftax.core import spread_1d, interp_1d, gaussian_kernel
+
+   kernel = gaussian_kernel(nspread=10, sigma=1.5)
+   fw = spread_1d(x, c, 256, kernel)   # spread Gaussians onto the grid
+   c2 = interp_1d(x, fw, 256, kernel)  # adjoint gather
+
+Any kernel can be defined by giving its support width and value function:
+
+.. code-block:: python
+
+   import jax.numpy as jnp
+   from nufftax.core import Kernel
+
+   # phi must be pure jnp arithmetic (it is also lowered into the GPU kernel)
+   def phi(z):
+       return jnp.exp(-0.5 * (z / 1.5) ** 2)
+
+   # Optional analytic derivative (z -> (phi, dphi/dz)); used for gradients
+   # w.r.t. the point coordinates. If omitted, it is obtained by autodiff.
+   def phi_and_dphi(z):
+       p = phi(z)
+       return p, -(z / 1.5**2) * p
+
+   kernel = Kernel(nspread=10, phi=phi, phi_and_dphi=phi_and_dphi)
+
+These primitives keep full ``grad``/``vjp`` support, including gradients w.r.t.
+the point coordinates (which use the kernel derivative).
+
+.. note::
+
+   **GPU.** Custom kernels run through the same fused Pallas spreading kernels
+   as the ES kernel — ``phi`` is threaded into the Triton kernel as a static
+   closure — so there is no performance penalty beyond the cost of ``phi``
+   itself. This requires ``phi`` to be pure ``jnp`` arithmetic (no Python
+   control flow on traced values) and passed as a static argument; a distinct
+   kernel triggers one Pallas recompilation.
+
+.. note::
+
+   Custom kernels apply to the standalone ``spread_*`` / ``interp_*``
+   primitives. The full ``nufftNdM`` transforms still use the ES kernel, whose
+   Fourier series is needed for the deconvolution step.
+
 Type 3 and JIT Compilation
 --------------------------
 

--- a/docs/concepts.rst
+++ b/docs/concepts.rst
@@ -174,6 +174,28 @@ The kernel width scales roughly as :math:`\lceil \log_{10}(1/\text{eps}) \rceil 
    # High precision
    f_precise = nufft1d1(x, c, n_modes=64, eps=1e-12)
 
+Oversampling factor (``upsampfac``)
+-----------------------------------
+
+All transforms accept ``upsampfac``, the oversampling factor of the internal
+fine grid (default ``2.0``). A smaller factor such as ``1.25`` shrinks the grid
+and is faster, at the cost of accuracy — note that nufftax uses a generic kernel
+formula, so at ``1.25`` it does not reach the same precision as the hand-tuned
+FINUFFT kernels.
+
+.. code-block:: python
+
+   f = nufft2d1(x, y, c, n_modes=(64, 64), upsampfac=1.25)  # faster, coarser
+
+For Type 1 / Type 2, ``upsampfac`` may also be a ``(forward, backward)`` pair:
+the forward transform and its adjoint (used in reverse-mode AD) need not share
+the same oversampling, which can be tuned independently for performance.
+
+.. code-block:: python
+
+   # forward at 2.0, gradient/adjoint at 1.25
+   f = nufft2d1(x, y, c, n_modes=(64, 64), upsampfac=(2.0, 1.25))
+
 Coordinate Conventions
 ----------------------
 

--- a/docs/concepts.rst
+++ b/docs/concepts.rst
@@ -243,34 +243,16 @@ The primitives live in ``nufftax.core``:
   :math:`c_j = \sum_k \text{fw}[k]\, \phi(k - \tilde{x}_j)`
 
 where :math:`\tilde{x}_j` is the point mapped to grid units and :math:`\phi` is
-the kernel, nonzero only over ``nspread`` neighbouring grid points.
+the kernel, nonzero only over ``nspread`` neighbouring grid points. By default
+they use the built-in ES kernel (the same one the ``nufftNdM`` transforms use).
 
-By default they take the ES kernel via ``compute_kernel_params``:
-
-.. code-block:: python
-
-   from nufftax.core import spread_1d, compute_kernel_params
-
-   kp = compute_kernel_params(1e-6)            # ES kernel (tol=1e-6)
-   fw = spread_1d(x, c, 256, kp)               # (x, c, nf, kernel)
-
-To use a custom kernel, pass a ``Kernel`` instead. A truncated Gaussian is
-provided out of the box:
-
-.. code-block:: python
-
-   from nufftax.core import spread_1d, interp_1d, gaussian_kernel
-
-   kernel = gaussian_kernel(nspread=10, sigma=1.5)
-   fw = spread_1d(x, c, 256, kernel)   # spread Gaussians onto the grid
-   c2 = interp_1d(x, fw, 256, kernel)  # adjoint gather
-
-Any kernel can be defined by giving its support width and value function:
+To use your own kernel, pass a ``Kernel`` instead — defined by its support
+width and value function. The example below is a truncated Gaussian:
 
 .. code-block:: python
 
    import jax.numpy as jnp
-   from nufftax.core import Kernel
+   from nufftax.core import spread_1d, interp_1d, Kernel
 
    # phi must be pure jnp arithmetic (it is also lowered into the GPU kernel)
    def phi(z):
@@ -283,6 +265,9 @@ Any kernel can be defined by giving its support width and value function:
        return p, -(z / 1.5**2) * p
 
    kernel = Kernel(nspread=10, phi=phi, phi_and_dphi=phi_and_dphi)
+
+   fw = spread_1d(x, c, 256, kernel)   # spread Gaussians onto the grid
+   c2 = interp_1d(x, fw, 256, kernel)  # adjoint gather
 
 These primitives keep full ``grad``/``vjp`` support, including gradients w.r.t.
 the point coordinates (which use the kernel derivative).

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -120,10 +120,10 @@ Quick Example
 GPU Acceleration
 ----------------
 
-On GPU, nufftax dispatches spreading to fused
-`Pallas <https://docs.jax.dev/en/latest/pallas/index.html>`_ (Triton) kernels
-by default. This avoids materializing O(M × nspread\ :sup:`d`) intermediate
-tensors and uses atomic scatter-add for spreading.
+On GPU, nufftax can dispatch spreading to fused
+`Pallas <https://docs.jax.dev/en/latest/pallas/index.html>`_ (Triton) kernels.
+This avoids materializing O(M × nspread\ :sup:`d`) intermediate tensors and
+uses atomic scatter-add for spreading.
 
 .. list-table::
    :widths: 30 20 30
@@ -142,9 +142,9 @@ tensors and uses atomic scatter-add for spreading.
      - A100/H100
      - 2–3× (M ≥ 100K)
 
-The dispatch is transparent — no code changes required. Set
-``NUFFTAX_PALLAS_BACKEND=0`` to force the pure-JAX path everywhere (more robust
-across JAX versions and GPU backends); on CPU the pure-JAX path is always used.
+The Pallas backend is opt-in: set ``NUFFTAX_PALLAS_BACKEND=1`` to enable it.
+By default nufftax uses the pure-JAX path everywhere, which is more robust
+across JAX versions and GPU backends; on CPU the pure-JAX path is always used.
 
 Installation
 ------------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -120,11 +120,10 @@ Quick Example
 GPU Acceleration
 ----------------
 
-On GPU, nufftax automatically dispatches spreading and interpolation to fused
+On GPU, nufftax dispatches spreading to fused
 `Pallas <https://docs.jax.dev/en/latest/pallas/index.html>`_ (Triton) kernels
-when the problem is large enough. This avoids materializing
-O(M × nspread\ :sup:`d`) intermediate tensors and uses atomic scatter-add for
-spreading.
+by default. This avoids materializing O(M × nspread\ :sup:`d`) intermediate
+tensors and uses atomic scatter-add for spreading.
 
 .. list-table::
    :widths: 30 20 30
@@ -143,8 +142,9 @@ spreading.
      - A100/H100
      - 2–3× (M ≥ 100K)
 
-The dispatch is transparent — no code changes required. On CPU or for small
-problems, the pure JAX path is used.
+The dispatch is transparent — no code changes required. Set
+``NUFFTAX_PALLAS_BACKEND=0`` to force the pure-JAX path everywhere (more robust
+across JAX versions and GPU backends); on CPU the pure-JAX path is always used.
 
 Installation
 ------------

--- a/nufftax/core/__init__.py
+++ b/nufftax/core/__init__.py
@@ -9,6 +9,7 @@ from .deconvolve import (
     deconvolve_shuffle_3d,
 )
 from .kernel import (
+    Kernel,
     KernelParams,
     compute_kernel_params,
     es_kernel,
@@ -33,6 +34,7 @@ __all__ = [
     "compute_kernel_params",
     "kernel_fourier_series",
     "KernelParams",
+    "Kernel",
     # Spreading functions
     "spread_1d",
     "spread_2d",

--- a/nufftax/core/kernel.py
+++ b/nufftax/core/kernel.py
@@ -9,7 +9,6 @@ Reference: FINUFFT include/finufft_common/kernel.h
 
 import math
 from collections.abc import Callable
-from dataclasses import dataclass
 from functools import partial
 from typing import NamedTuple
 
@@ -26,8 +25,7 @@ class KernelParams(NamedTuple):
     upsampfac: float  # Upsampling factor (default 2.0)
 
 
-@dataclass(frozen=True)
-class Kernel:
+class Kernel(NamedTuple):
     """A user-supplied spreading/interpolation kernel.
 
     Lets ``spread_*`` / ``interp_*`` use an arbitrary kernel instead of the
@@ -45,8 +43,11 @@ class Kernel:
             from ``phi`` by autodiff (pure-JAX path only).
 
     Note:
-        This is hashable (frozen, callable fields) so it can be passed as the
-        static kernel argument, exactly like ``KernelParams``.
+        A ``NamedTuple`` (like ``KernelParams``) so it is a JAX pytree and stays
+        hashable for use as the static kernel argument. Kernel parameters baked
+        into a closed-over ``phi`` are differentiable when the kernel is built
+        inside the differentiated function and the pure-JAX spread/interp path is
+        used (the Pallas path keeps ``phi`` static).
     """
 
     nspread: int

--- a/nufftax/core/kernel.py
+++ b/nufftax/core/kernel.py
@@ -8,6 +8,8 @@ Reference: FINUFFT include/finufft_common/kernel.h
 """
 
 import math
+from collections.abc import Callable
+from dataclasses import dataclass
 from functools import partial
 from typing import NamedTuple
 
@@ -22,6 +24,55 @@ class KernelParams(NamedTuple):
     beta: float  # Shape parameter
     c: float  # Normalization parameter = 4/nspread^2
     upsampfac: float  # Upsampling factor (default 2.0)
+
+
+@dataclass(frozen=True)
+class Kernel:
+    """A user-supplied spreading/interpolation kernel.
+
+    Lets ``spread_*`` / ``interp_*`` use an arbitrary kernel instead of the
+    built-in ES kernel (e.g. a short-range Gaussian). The support is the
+    ``nspread`` grid points around each nonuniform point, i.e. ``phi`` is only
+    ever evaluated for ``z`` in ``[-nspread/2, nspread/2]``.
+
+    Args:
+        nspread: Kernel width in grid points (static).
+        phi: ``z -> phi(z)``. Must be pure ``jnp`` arithmetic so it lowers both
+            in plain JAX and inside the Pallas/Triton kernels (no Python control
+            flow on traced values).
+        phi_and_dphi: Optional ``z -> (phi(z), dphi/dz)``, used for gradients
+            w.r.t. the point coordinates. If ``None``, the derivative is obtained
+            from ``phi`` by autodiff (pure-JAX path only).
+
+    Note:
+        This is hashable (frozen, callable fields) so it can be passed as the
+        static kernel argument, exactly like ``KernelParams``.
+    """
+
+    nspread: int
+    phi: Callable[[jax.Array], jax.Array]
+    phi_and_dphi: Callable[[jax.Array], tuple[jax.Array, jax.Array]] | None = None
+
+    def value(self, z: jax.Array) -> jax.Array:
+        return self.phi(z)
+
+    def value_and_grad(self, z: jax.Array) -> tuple[jax.Array, jax.Array]:
+        if self.phi_and_dphi is not None:
+            return self.phi_and_dphi(z)
+        # Fallback: differentiate the (elementwise, real) kernel with autodiff.
+        grad_phi = jax.grad(lambda zi: self.phi(zi))
+        dphi = jax.vmap(grad_phi)(z.reshape(-1)).reshape(z.shape)
+        return self.phi(z), dphi
+
+
+def es_kernel_spec(kernel_params: KernelParams) -> Kernel:
+    """Wrap the built-in ES kernel as a :class:`Kernel` (used internally)."""
+    beta, c = kernel_params.beta, kernel_params.c
+    return Kernel(
+        nspread=kernel_params.nspread,
+        phi=lambda z: es_kernel(z, beta, c),
+        phi_and_dphi=lambda z: es_kernel_with_derivative(z, beta, c),
+    )
 
 
 def es_kernel(z: jax.Array, beta: float, c: float) -> jax.Array:

--- a/nufftax/core/pallas_spread.py
+++ b/nufftax/core/pallas_spread.py
@@ -18,8 +18,22 @@ import jax.numpy as jnp
 from jax.experimental import pallas as pl
 from jax.experimental.pallas import triton as pltriton
 
+from .kernel import Kernel
+
 
 BLOCK_SIZE = 256
+
+
+def _kernel_eval_params(kernel_params):
+    """Extract Pallas kernel-eval params: (nspread, beta, c, phi).
+
+    For a custom ``Kernel``, ``phi`` is its (Triton-lowerable) value function
+    and ``beta``/``c`` are unused placeholders. For ``KernelParams`` (ES),
+    ``phi`` is ``None`` and the inlined ES formula is used.
+    """
+    if isinstance(kernel_params, Kernel):
+        return kernel_params.nspread, 0.0, 0.0, kernel_params.phi
+    return kernel_params.nspread, float(kernel_params.beta), float(kernel_params.c), None
 
 
 # ============================================================================
@@ -34,9 +48,15 @@ def _fold_rescale(x, nf):
     return (x_scaled - jnp.floor(x_scaled)) * nf
 
 
-def _eval_kernel_1d(i0, k, x_scaled, beta, c):
-    """Evaluate ES kernel weight for offset k from i0."""
+def _eval_kernel_1d(i0, k, x_scaled, beta, c, phi=None):
+    """Evaluate kernel weight for offset k from i0.
+
+    Uses the inlined ES formula by default; if ``phi`` is given (custom kernel),
+    it is called directly on ``z`` (must be Triton-lowerable jnp arithmetic).
+    """
     z = (i0 + k).astype(x_scaled.dtype) - x_scaled
+    if phi is not None:
+        return phi(z)
     arg = 1.0 - c * z * z
     return jnp.where(arg >= 0, jnp.exp(beta * (jnp.sqrt(jnp.maximum(arg, 0.0)) - 1.0)), 0.0)
 
@@ -59,6 +79,7 @@ def _spread_1d_kernel(
     nspread,
     beta,
     c,
+    phi,
 ):
     x = x_ref[:]
     cr, ci = c_real_ref[:], c_imag_ref[:]
@@ -67,13 +88,14 @@ def _spread_1d_kernel(
 
     for k in range(nspread):
         idx = (i0 + k) % nf
-        w = _eval_kernel_1d(i0, k, x_scaled, beta, c)
+        w = _eval_kernel_1d(i0, k, x_scaled, beta, c, phi)
         pltriton.atomic_add(fw_real_out_ref, idx, cr * w)
         pltriton.atomic_add(fw_imag_out_ref, idx, ci * w)
 
 
 def spread_1d_pallas(x, c, nf, kernel_params):
     """1D spreading using fused Pallas kernel with atomic scatter-add."""
+    nspread, beta, kc, phi = _kernel_eval_params(kernel_params)
     M = x.shape[0]
     M_pad = ((M + BLOCK_SIZE - 1) // BLOCK_SIZE) * BLOCK_SIZE
     x_pad = jnp.pad(x.astype(jnp.float32), (0, M_pad - M))
@@ -85,9 +107,10 @@ def spread_1d_pallas(x, c, nf, kernel_params):
     kernel_fn = functools.partial(
         _spread_1d_kernel,
         nf=nf,
-        nspread=kernel_params.nspread,
-        beta=float(kernel_params.beta),
-        c=float(kernel_params.c),
+        nspread=nspread,
+        beta=beta,
+        c=kc,
+        phi=phi,
     )
     fw_real, fw_imag = pl.pallas_call(
         kernel_fn,
@@ -133,6 +156,7 @@ def _spread_2d_kernel(
     nspread,
     beta,
     c,
+    phi,
 ):
     x, y = x_ref[:], y_ref[:]
     cr, ci = c_real_ref[:], c_imag_ref[:]
@@ -145,11 +169,11 @@ def _spread_2d_kernel(
     wx_vals, idx_x_vals = [], []
     for kx in range(nspread):
         idx_x_vals.append((i0_x + kx) % nf1)
-        wx_vals.append(_eval_kernel_1d(i0_x, kx, x_scaled, beta, c))
+        wx_vals.append(_eval_kernel_1d(i0_x, kx, x_scaled, beta, c, phi))
     wy_vals, idy_vals = [], []
     for ky in range(nspread):
         idy_vals.append((i0_y + ky) % nf2)
-        wy_vals.append(_eval_kernel_1d(i0_y, ky, y_scaled, beta, c))
+        wy_vals.append(_eval_kernel_1d(i0_y, ky, y_scaled, beta, c, phi))
 
     for ky in range(nspread):
         for kx in range(nspread):
@@ -161,6 +185,7 @@ def _spread_2d_kernel(
 
 def spread_2d_pallas(x, y, c, nf1, nf2, kernel_params):
     """2D spreading using fused Pallas kernel with atomic scatter-add."""
+    nspread, beta, kc, phi = _kernel_eval_params(kernel_params)
     M = x.shape[0]
     nf_total = nf1 * nf2
     M_pad = ((M + BLOCK_SIZE - 1) // BLOCK_SIZE) * BLOCK_SIZE
@@ -175,9 +200,10 @@ def spread_2d_pallas(x, y, c, nf1, nf2, kernel_params):
         _spread_2d_kernel,
         nf1=nf1,
         nf2=nf2,
-        nspread=kernel_params.nspread,
-        beta=float(kernel_params.beta),
-        c=float(kernel_params.c),
+        nspread=nspread,
+        beta=beta,
+        c=kc,
+        phi=phi,
     )
     fw_real, fw_imag = pl.pallas_call(
         kernel_fn,
@@ -226,6 +252,7 @@ def _spread_3d_kernel(
     nspread,
     beta,
     c,
+    phi,
 ):
     x, y, z = x_ref[:], y_ref[:], z_ref[:]
     cr, ci = c_real_ref[:], c_imag_ref[:]
@@ -244,15 +271,15 @@ def _spread_3d_kernel(
     nf12 = nf1 * nf2
 
     def kz_body(kz, _):
-        wz = _eval_kernel_1d(i0_z, kz, z_scaled, beta, c)
+        wz = _eval_kernel_1d(i0_z, kz, z_scaled, beta, c, phi)
         base_z = ((i0_z + kz) % nf3) * nf12
 
         def ky_body(ky, _):
-            wyz = wz * _eval_kernel_1d(i0_y, ky, y_scaled, beta, c)
+            wyz = wz * _eval_kernel_1d(i0_y, ky, y_scaled, beta, c, phi)
             base_yz = base_z + ((i0_y + ky) % nf2) * nf1
 
             def kx_body(kx, _):
-                w = wyz * _eval_kernel_1d(i0_x, kx, x_scaled, beta, c)
+                w = wyz * _eval_kernel_1d(i0_x, kx, x_scaled, beta, c, phi)
                 flat_idx = base_yz + ((i0_x + kx) % nf1)
                 pltriton.atomic_add(fw_real_out_ref, flat_idx, cr * w)
                 pltriton.atomic_add(fw_imag_out_ref, flat_idx, ci * w)
@@ -267,6 +294,7 @@ def _spread_3d_kernel(
 
 def spread_3d_pallas(x, y, z, c, nf1, nf2, nf3, kernel_params):
     """3D spreading using fused Pallas kernel with atomic scatter-add."""
+    nspread, beta, kc, phi = _kernel_eval_params(kernel_params)
     M = x.shape[0]
     nf_total = nf1 * nf2 * nf3
     M_pad = ((M + BLOCK_SIZE - 1) // BLOCK_SIZE) * BLOCK_SIZE
@@ -283,9 +311,10 @@ def spread_3d_pallas(x, y, z, c, nf1, nf2, nf3, kernel_params):
         nf1=nf1,
         nf2=nf2,
         nf3=nf3,
-        nspread=kernel_params.nspread,
-        beta=float(kernel_params.beta),
-        c=float(kernel_params.c),
+        nspread=nspread,
+        beta=beta,
+        c=kc,
+        phi=phi,
     )
     fw_real, fw_imag = pl.pallas_call(
         kernel_fn,

--- a/nufftax/core/pallas_spread.py
+++ b/nufftax/core/pallas_spread.py
@@ -12,6 +12,7 @@ interp kernels are provided.
 """
 
 import functools
+import os
 
 import jax
 import jax.numpy as jnp
@@ -22,6 +23,13 @@ from .kernel import Kernel
 
 
 BLOCK_SIZE = 256
+
+# Testing/debugging only: run the Pallas kernels in interpret mode (works on
+# CPU, no Triton). This validates indexing, kernel weights and dtype handling,
+# but interpret mode does NOT emulate atomic accumulation for duplicate indices
+# within a call — points whose kernel footprints overlap give wrong sums. Tests
+# using this flag must use collision-free points. Never enable in production.
+INTERPRET = os.environ.get("NUFFTAX_PALLAS_INTERPRET", "").strip().lower() in ("1", "true", "yes", "on")
 
 
 def _kernel_eval_params(kernel_params):
@@ -132,6 +140,7 @@ def spread_1d_pallas(x, c, nf, kernel_params):
         ],
         input_output_aliases={3: 0, 4: 1},
         compiler_params=pltriton.CompilerParams(num_warps=4, num_stages=2),
+        interpret=INTERPRET,
     )(x_pad, c_real_pad, c_imag_pad, fw_real_init, fw_imag_init)
     return (fw_real + 1j * fw_imag).astype(c.dtype)
 
@@ -226,6 +235,7 @@ def spread_2d_pallas(x, y, c, nf1, nf2, kernel_params):
         ],
         input_output_aliases={4: 0, 5: 1},
         compiler_params=pltriton.CompilerParams(num_warps=4, num_stages=2),
+        interpret=INTERPRET,
     )(x_pad, y_pad, c_real_pad, c_imag_pad, fw_real_init, fw_imag_init)
     return (fw_real + 1j * fw_imag).astype(c.dtype).reshape(nf2, nf1)
 
@@ -338,5 +348,6 @@ def spread_3d_pallas(x, y, z, c, nf1, nf2, nf3, kernel_params):
         ],
         input_output_aliases={5: 0, 6: 1},
         compiler_params=pltriton.CompilerParams(num_warps=4, num_stages=2),
+        interpret=INTERPRET,
     )(x_pad, y_pad, z_pad, c_real_pad, c_imag_pad, fw_real_init, fw_imag_init)
     return (fw_real + 1j * fw_imag).astype(c.dtype).reshape(nf3, nf2, nf1)

--- a/nufftax/core/spread.py
+++ b/nufftax/core/spread.py
@@ -40,11 +40,12 @@ except ImportError:
     pass
 
 
-# Whether to use the fused Pallas GPU spreading kernels. Gated by the
-# NUFFTAX_PALLAS_BACKEND environment variable (default on). Set it to a falsey
-# value (0/false/no/off) to force the pure-JAX path everywhere — slower for
-# large problems, but more robust across JAX versions and GPU backends. Pallas
-# additionally requires a GPU (Triton); on CPU the pure-JAX path is always used.
+# Whether to use the fused Pallas GPU spreading kernels. Opt-in via the
+# NUFFTAX_PALLAS_BACKEND environment variable (default off): pure JAX is the
+# default because it is robust across JAX versions and GPU backends. Set a
+# truthy value (1/true/yes/on) to enable the Pallas kernels — much faster
+# spreading for large problems on GPU. Pallas additionally requires a GPU
+# (Triton); on CPU the pure-JAX path is always used.
 def _bool_env(name: str, default: bool) -> bool:
     val = os.environ.get(name)
     if val is None:
@@ -52,7 +53,7 @@ def _bool_env(name: str, default: bool) -> bool:
     return val.strip().lower() not in ("0", "false", "no", "off", "")
 
 
-_USE_PALLAS_SPREAD = _bool_env("NUFFTAX_PALLAS_BACKEND", True)
+_USE_PALLAS_SPREAD = _bool_env("NUFFTAX_PALLAS_BACKEND", False)
 
 
 def _use_pallas(x: jax.Array, c: jax.Array) -> bool:

--- a/nufftax/core/spread.py
+++ b/nufftax/core/spread.py
@@ -50,6 +50,19 @@ def _bool_env(name: str, default: bool) -> bool:
 
 _USE_PALLAS_SPREAD = _bool_env("NUFFTAX_PALLAS_BACKEND", True)
 
+
+def _use_pallas(x: jax.Array, c: jax.Array) -> bool:
+    """Whether to route this spread to the Pallas kernels.
+
+    Requires the backend enabled (env var) and a GPU. The Pallas kernels compute
+    in float32, so only fully 32-bit inputs (float32 coordinates, complex64
+    strengths) take the Pallas path; any 64-bit input (x64 / complex128) falls
+    back to pure JAX, which both preserves accuracy and keeps dtypes consistent
+    across the AD rules.
+    """
+    return _USE_PALLAS_SPREAD and _HAS_PALLAS_GPU and x.dtype == jnp.float32 and c.dtype == jnp.complex64
+
+
 # ============================================================================
 # Helper functions
 # ============================================================================
@@ -696,7 +709,7 @@ def interp_3d_impl(
 
 def _spread_1d_dispatch(x, c, nf, kernel_params):
     """Dispatch 1D spreading to Pallas GPU or pure JAX."""
-    if _USE_PALLAS_SPREAD and _HAS_PALLAS_GPU:
+    if _use_pallas(x, c):
         if c.ndim == 1:
             return spread_1d_pallas(x, c, nf, kernel_params)
         return jax.vmap(lambda ci: spread_1d_pallas(x, ci, nf, kernel_params))(c)
@@ -705,7 +718,7 @@ def _spread_1d_dispatch(x, c, nf, kernel_params):
 
 def _spread_2d_dispatch(x, y, c, nf1, nf2, kernel_params):
     """Dispatch 2D spreading to Pallas GPU or pure JAX."""
-    if _USE_PALLAS_SPREAD and _HAS_PALLAS_GPU:
+    if _use_pallas(x, c):
         if c.ndim == 1:
             return spread_2d_pallas(x, y, c, nf1, nf2, kernel_params)
         return jax.vmap(lambda ci: spread_2d_pallas(x, y, ci, nf1, nf2, kernel_params))(c)
@@ -727,7 +740,7 @@ def _interp_2d_dispatch(x, y, fw, kernel_params):
 
 def _spread_3d_dispatch(x, y, z, c, nf1, nf2, nf3, kernel_params):
     """Dispatch 3D spreading to Pallas GPU or pure JAX."""
-    if _USE_PALLAS_SPREAD and _HAS_PALLAS_GPU:
+    if _use_pallas(x, c):
         if c.ndim == 1:
             return spread_3d_pallas(x, y, z, c, nf1, nf2, nf3, kernel_params)
         return jax.vmap(lambda ci: spread_3d_pallas(x, y, z, ci, nf1, nf2, nf3, kernel_params))(c)

--- a/nufftax/core/spread.py
+++ b/nufftax/core/spread.py
@@ -15,7 +15,7 @@ from functools import partial
 import jax
 import jax.numpy as jnp
 
-from .kernel import KernelParams, es_kernel, es_kernel_with_derivative
+from .kernel import Kernel, KernelParams, es_kernel_spec
 
 
 # ============================================================================
@@ -145,10 +145,21 @@ def _prepare_batched_grid_3d(fw: jax.Array) -> tuple[jax.Array, int, int, int, i
     return fw.reshape(1, dim0 * dim1 * dim2), dim2, dim1, dim0, 1, False
 
 
+def _as_kernel(kernel: "Kernel | KernelParams") -> Kernel:
+    """Normalize a kernel argument to a :class:`Kernel`.
+
+    Accepts either ``KernelParams`` (built-in ES kernel) or a user-supplied
+    ``Kernel``. Idempotent on ``Kernel``.
+    """
+    if isinstance(kernel, Kernel):
+        return kernel
+    return es_kernel_spec(kernel)
+
+
 def compute_kernel_weights_1d(
     x_scaled: jax.Array,
     nf: int,
-    kernel_params: KernelParams,
+    kernel_params: "Kernel | KernelParams",
 ) -> tuple[jax.Array, jax.Array]:
     """
     Compute kernel weights and grid indices for 1D spreading/interpolation.
@@ -160,15 +171,14 @@ def compute_kernel_weights_1d(
     Args:
         x_scaled: Scaled coordinates in [0, nf), shape (M,)
         nf: Fine grid size
-        kernel_params: Kernel parameters
+        kernel_params: Kernel parameters (ES) or a custom Kernel
 
     Returns:
         indices: Grid indices, shape (M, nspread)
         weights: Kernel weights, shape (M, nspread)
     """
-    nspread = kernel_params.nspread
-    beta = kernel_params.beta
-    c = kernel_params.c
+    kernel = _as_kernel(kernel_params)
+    nspread = kernel.nspread
 
     # Half kernel width
     ns2 = nspread / 2.0
@@ -192,7 +202,7 @@ def compute_kernel_weights_1d(
     z = indices.astype(x_scaled.dtype) - x_scaled[:, None]
 
     # Evaluate kernel
-    weights = es_kernel(z, beta, c)
+    weights = kernel.value(z)
 
     return indices_wrapped, weights
 
@@ -215,9 +225,8 @@ def compute_kernel_weights_derivative_1d(
         weights: Kernel weights, shape (M, nspread)
         dweights: Kernel weight derivatives w.r.t. x, shape (M, nspread)
     """
-    nspread = kernel_params.nspread
-    beta = kernel_params.beta
-    c = kernel_params.c
+    kernel = _as_kernel(kernel_params)
+    nspread = kernel.nspread
 
     ns2 = nspread / 2.0
     i0 = jnp.ceil(x_scaled - ns2).astype(jnp.int32)
@@ -228,7 +237,7 @@ def compute_kernel_weights_derivative_1d(
     z = indices.astype(x_scaled.dtype) - x_scaled[:, None]
 
     # Use fused computation for efficiency (computes both in single pass)
-    weights, dweights_dz = es_kernel_with_derivative(z, beta, c)
+    weights, dweights_dz = kernel.value_and_grad(z)
     # Derivative of kernel w.r.t. z, but we need w.r.t. x
     # Since z = grid_idx - x_scaled, dz/dx = -1 (in grid units)
     # And x_scaled = x * nf / (2*pi), so dx_scaled/dx = nf / (2*pi)
@@ -374,9 +383,8 @@ def compute_kernel_weights_2d(
         weights_x: X kernel weights, shape (M, nspread)
         weights_y: Y kernel weights, shape (M, nspread)
     """
-    nspread = kernel_params.nspread
-    beta = kernel_params.beta
-    c = kernel_params.c
+    kernel = _as_kernel(kernel_params)
+    nspread = kernel.nspread
 
     ns2 = nspread / 2.0
     offsets = jnp.arange(nspread)
@@ -385,13 +393,13 @@ def compute_kernel_weights_2d(
     i0_x = jnp.ceil(x_scaled - ns2).astype(jnp.int32)
     indices_x = (i0_x[:, None] + offsets[None, :]) % nf1
     z_x = (i0_x[:, None] + offsets[None, :]).astype(x_scaled.dtype) - x_scaled[:, None]
-    weights_x = es_kernel(z_x, beta, c)
+    weights_x = kernel.value(z_x)
 
     # Y dimension
     i0_y = jnp.ceil(y_scaled - ns2).astype(jnp.int32)
     indices_y = (i0_y[:, None] + offsets[None, :]) % nf2
     z_y = (i0_y[:, None] + offsets[None, :]).astype(y_scaled.dtype) - y_scaled[:, None]
-    weights_y = es_kernel(z_y, beta, c)
+    weights_y = kernel.value(z_y)
 
     return indices_x, indices_y, weights_x, weights_y
 
@@ -530,9 +538,8 @@ def compute_kernel_weights_3d(
         indices_x, indices_y, indices_z: Grid indices, shape (M, nspread) each
         weights_x, weights_y, weights_z: Kernel weights, shape (M, nspread) each
     """
-    nspread = kernel_params.nspread
-    beta = kernel_params.beta
-    c = kernel_params.c
+    kernel = _as_kernel(kernel_params)
+    nspread = kernel.nspread
 
     ns2 = nspread / 2.0
     offsets = jnp.arange(nspread)
@@ -541,19 +548,19 @@ def compute_kernel_weights_3d(
     i0_x = jnp.ceil(x_scaled - ns2).astype(jnp.int32)
     indices_x = (i0_x[:, None] + offsets[None, :]) % nf1
     z_x = (i0_x[:, None] + offsets[None, :]).astype(x_scaled.dtype) - x_scaled[:, None]
-    weights_x = es_kernel(z_x, beta, c)
+    weights_x = kernel.value(z_x)
 
     # Y dimension
     i0_y = jnp.ceil(y_scaled - ns2).astype(jnp.int32)
     indices_y = (i0_y[:, None] + offsets[None, :]) % nf2
     z_y = (i0_y[:, None] + offsets[None, :]).astype(y_scaled.dtype) - y_scaled[:, None]
-    weights_y = es_kernel(z_y, beta, c)
+    weights_y = kernel.value(z_y)
 
     # Z dimension
     i0_z = jnp.ceil(z_scaled - ns2).astype(jnp.int32)
     indices_z = (i0_z[:, None] + offsets[None, :]) % nf3
     z_z = (i0_z[:, None] + offsets[None, :]).astype(z_scaled.dtype) - z_scaled[:, None]
-    weights_z = es_kernel(z_z, beta, c)
+    weights_z = kernel.value(z_z)
 
     return indices_x, indices_y, indices_z, weights_x, weights_y, weights_z
 
@@ -964,9 +971,8 @@ def _spread_2d_grad_xy(x, y, c, g, nf1, nf2, kernel_params):
     c_flat, _, _ = _prepare_batched_c(c)
     g_flat, _, _, _, _ = _prepare_batched_grid_2d(g)
     M = x.shape[0]
-    nspread = kernel_params.nspread
-    beta = kernel_params.beta
-    kc = kernel_params.c
+    kernel = _as_kernel(kernel_params)
+    nspread = kernel.nspread
 
     # Scale coordinates
     x_scaled = fold_rescale(x, nf1)
@@ -981,14 +987,14 @@ def _spread_2d_grad_xy(x, y, c, g, nf1, nf2, kernel_params):
     i0_x = jnp.ceil(x_scaled - ns2).astype(jnp.int32)
     indices_x = (i0_x[:, None] + offsets[None, :]) % nf1
     z_x = (i0_x[:, None] + offsets[None, :]).astype(x.dtype) - x_scaled[:, None]
-    weights_x, dweights_x_raw = es_kernel_with_derivative(z_x, beta, kc)
+    weights_x, dweights_x_raw = kernel.value_and_grad(z_x)
     dweights_x = -dweights_x_raw * scale_x
 
     # Y dimension (fused kernel + derivative computation)
     i0_y = jnp.ceil(y_scaled - ns2).astype(jnp.int32)
     indices_y = (i0_y[:, None] + offsets[None, :]) % nf2
     z_y = (i0_y[:, None] + offsets[None, :]).astype(y.dtype) - y_scaled[:, None]
-    weights_y, dweights_y_raw = es_kernel_with_derivative(z_y, beta, kc)
+    weights_y, dweights_y_raw = kernel.value_and_grad(z_y)
     dweights_y = -dweights_y_raw * scale_y
 
     # 2D indices
@@ -1063,9 +1069,8 @@ def _interp_2d_grad_xy(x, y, fw, g, nf1, nf2, kernel_params):
     fw_flat, _, _, _, _ = _prepare_batched_grid_2d(fw)
     g_flat, _, _ = _prepare_batched_c(g)
     M = x.shape[0]
-    nspread = kernel_params.nspread
-    beta = kernel_params.beta
-    kc = kernel_params.c
+    kernel = _as_kernel(kernel_params)
+    nspread = kernel.nspread
 
     x_scaled = fold_rescale(x, nf1)
     y_scaled = fold_rescale(y, nf2)
@@ -1079,14 +1084,14 @@ def _interp_2d_grad_xy(x, y, fw, g, nf1, nf2, kernel_params):
     i0_x = jnp.ceil(x_scaled - ns2).astype(jnp.int32)
     indices_x = (i0_x[:, None] + offsets[None, :]) % nf1
     z_x = (i0_x[:, None] + offsets[None, :]).astype(x.dtype) - x_scaled[:, None]
-    weights_x, dweights_x_raw = es_kernel_with_derivative(z_x, beta, kc)
+    weights_x, dweights_x_raw = kernel.value_and_grad(z_x)
     dweights_x = -dweights_x_raw * scale_x
 
     # Y dimension (fused kernel + derivative computation)
     i0_y = jnp.ceil(y_scaled - ns2).astype(jnp.int32)
     indices_y = (i0_y[:, None] + offsets[None, :]) % nf2
     z_y = (i0_y[:, None] + offsets[None, :]).astype(y.dtype) - y_scaled[:, None]
-    weights_y, dweights_y_raw = es_kernel_with_derivative(z_y, beta, kc)
+    weights_y, dweights_y_raw = kernel.value_and_grad(z_y)
     dweights_y = -dweights_y_raw * scale_y
 
     # 2D indices
@@ -1167,9 +1172,8 @@ def _spread_3d_grad_xyz(x, y, z, c, g, nf1, nf2, nf3, kernel_params):
     c_flat, _, _ = _prepare_batched_c(c)
     g_flat, _, _, _, _, _ = _prepare_batched_grid_3d(g)
     M = x.shape[0]
-    nspread = kernel_params.nspread
-    beta = kernel_params.beta
-    kc = kernel_params.c
+    kernel = _as_kernel(kernel_params)
+    nspread = kernel.nspread
 
     x_scaled = fold_rescale(x, nf1)
     y_scaled = fold_rescale(y, nf2)
@@ -1185,21 +1189,21 @@ def _spread_3d_grad_xyz(x, y, z, c, g, nf1, nf2, nf3, kernel_params):
     i0_x = jnp.ceil(x_scaled - ns2).astype(jnp.int32)
     indices_x = (i0_x[:, None] + offsets[None, :]) % nf1
     z_x = (i0_x[:, None] + offsets[None, :]).astype(x.dtype) - x_scaled[:, None]
-    weights_x, dweights_x_raw = es_kernel_with_derivative(z_x, beta, kc)
+    weights_x, dweights_x_raw = kernel.value_and_grad(z_x)
     dweights_x = -dweights_x_raw * scale_x
 
     # Y dimension (fused kernel + derivative computation)
     i0_y = jnp.ceil(y_scaled - ns2).astype(jnp.int32)
     indices_y = (i0_y[:, None] + offsets[None, :]) % nf2
     z_y = (i0_y[:, None] + offsets[None, :]).astype(y.dtype) - y_scaled[:, None]
-    weights_y, dweights_y_raw = es_kernel_with_derivative(z_y, beta, kc)
+    weights_y, dweights_y_raw = kernel.value_and_grad(z_y)
     dweights_y = -dweights_y_raw * scale_y
 
     # Z dimension (fused kernel + derivative computation)
     i0_z = jnp.ceil(z_scaled - ns2).astype(jnp.int32)
     indices_z = (i0_z[:, None] + offsets[None, :]) % nf3
     z_z = (i0_z[:, None] + offsets[None, :]).astype(z.dtype) - z_scaled[:, None]
-    weights_z, dweights_z_raw = es_kernel_with_derivative(z_z, beta, kc)
+    weights_z, dweights_z_raw = kernel.value_and_grad(z_z)
     dweights_z = -dweights_z_raw * scale_z
 
     # 3D indices
@@ -1283,9 +1287,8 @@ def _interp_3d_grad_xyz(x, y, z, fw, g, nf1, nf2, nf3, kernel_params):
     fw_flat, _, _, _, _, _ = _prepare_batched_grid_3d(fw)
     g_flat, _, _ = _prepare_batched_c(g)
     M = x.shape[0]
-    nspread = kernel_params.nspread
-    beta = kernel_params.beta
-    kc = kernel_params.c
+    kernel = _as_kernel(kernel_params)
+    nspread = kernel.nspread
 
     x_scaled = fold_rescale(x, nf1)
     y_scaled = fold_rescale(y, nf2)
@@ -1301,21 +1304,21 @@ def _interp_3d_grad_xyz(x, y, z, fw, g, nf1, nf2, nf3, kernel_params):
     i0_x = jnp.ceil(x_scaled - ns2).astype(jnp.int32)
     indices_x = (i0_x[:, None] + offsets[None, :]) % nf1
     z_x = (i0_x[:, None] + offsets[None, :]).astype(x.dtype) - x_scaled[:, None]
-    weights_x, dweights_x_raw = es_kernel_with_derivative(z_x, beta, kc)
+    weights_x, dweights_x_raw = kernel.value_and_grad(z_x)
     dweights_x = -dweights_x_raw * scale_x
 
     # Y dimension (fused kernel + derivative computation)
     i0_y = jnp.ceil(y_scaled - ns2).astype(jnp.int32)
     indices_y = (i0_y[:, None] + offsets[None, :]) % nf2
     z_y = (i0_y[:, None] + offsets[None, :]).astype(y.dtype) - y_scaled[:, None]
-    weights_y, dweights_y_raw = es_kernel_with_derivative(z_y, beta, kc)
+    weights_y, dweights_y_raw = kernel.value_and_grad(z_y)
     dweights_y = -dweights_y_raw * scale_y
 
     # Z dimension (fused kernel + derivative computation)
     i0_z = jnp.ceil(z_scaled - ns2).astype(jnp.int32)
     indices_z = (i0_z[:, None] + offsets[None, :]) % nf3
     z_z = (i0_z[:, None] + offsets[None, :]).astype(z.dtype) - z_scaled[:, None]
-    weights_z, dweights_z_raw = es_kernel_with_derivative(z_z, beta, kc)
+    weights_z, dweights_z_raw = kernel.value_and_grad(z_z)
     dweights_z = -dweights_z_raw * scale_z
 
     # 3D indices

--- a/nufftax/core/spread.py
+++ b/nufftax/core/spread.py
@@ -10,6 +10,7 @@ The implementation uses pure JAX operations to enable automatic differentiation.
 Reference: FINUFFT src/spreadinterp.cpp
 """
 
+import os
 from functools import partial
 
 import jax
@@ -34,13 +35,20 @@ try:
 except ImportError:
     pass
 
-# Spreading (Type 1 scatter) on GPU: per-dimension crossover where the fused
-# Pallas kernels overtake the pure-JAX scatter (measured on H100; below the
-# threshold kernel-launch + BLOCK_SIZE padding dominate). Above these points
-# Pallas wins 1.5x to 30x+.
-_PALLAS_MIN_M_SPREAD_1D = 5_000
-_PALLAS_MIN_M_SPREAD_2D = 5_000
-_PALLAS_MIN_M_SPREAD_3D = 10_000
+
+# Whether to use the fused Pallas GPU spreading kernels. Gated by the
+# NUFFTAX_PALLAS_BACKEND environment variable (default on). Set it to a falsey
+# value (0/false/no/off) to force the pure-JAX path everywhere — slower for
+# large problems, but more robust across JAX versions and GPU backends. Pallas
+# additionally requires a GPU (Triton); on CPU the pure-JAX path is always used.
+def _bool_env(name: str, default: bool) -> bool:
+    val = os.environ.get(name)
+    if val is None:
+        return default
+    return val.strip().lower() not in ("0", "false", "no", "off", "")
+
+
+_USE_PALLAS_SPREAD = _bool_env("NUFFTAX_PALLAS_BACKEND", True)
 
 # ============================================================================
 # Helper functions
@@ -688,7 +696,7 @@ def interp_3d_impl(
 
 def _spread_1d_dispatch(x, c, nf, kernel_params):
     """Dispatch 1D spreading to Pallas GPU or pure JAX."""
-    if _HAS_PALLAS_GPU and x.shape[0] >= _PALLAS_MIN_M_SPREAD_1D:
+    if _USE_PALLAS_SPREAD and _HAS_PALLAS_GPU:
         if c.ndim == 1:
             return spread_1d_pallas(x, c, nf, kernel_params)
         return jax.vmap(lambda ci: spread_1d_pallas(x, ci, nf, kernel_params))(c)
@@ -697,7 +705,7 @@ def _spread_1d_dispatch(x, c, nf, kernel_params):
 
 def _spread_2d_dispatch(x, y, c, nf1, nf2, kernel_params):
     """Dispatch 2D spreading to Pallas GPU or pure JAX."""
-    if _HAS_PALLAS_GPU and x.shape[0] >= _PALLAS_MIN_M_SPREAD_2D:
+    if _USE_PALLAS_SPREAD and _HAS_PALLAS_GPU:
         if c.ndim == 1:
             return spread_2d_pallas(x, y, c, nf1, nf2, kernel_params)
         return jax.vmap(lambda ci: spread_2d_pallas(x, y, ci, nf1, nf2, kernel_params))(c)
@@ -719,7 +727,7 @@ def _interp_2d_dispatch(x, y, fw, kernel_params):
 
 def _spread_3d_dispatch(x, y, z, c, nf1, nf2, nf3, kernel_params):
     """Dispatch 3D spreading to Pallas GPU or pure JAX."""
-    if _HAS_PALLAS_GPU and x.shape[0] >= _PALLAS_MIN_M_SPREAD_3D:
+    if _USE_PALLAS_SPREAD and _HAS_PALLAS_GPU:
         if c.ndim == 1:
             return spread_3d_pallas(x, y, z, c, nf1, nf2, nf3, kernel_params)
         return jax.vmap(lambda ci: spread_3d_pallas(x, y, z, ci, nf1, nf2, nf3, kernel_params))(c)
@@ -740,7 +748,7 @@ def spread_1d(
     x: jax.Array,
     c: jax.Array,
     nf: int,
-    kernel_params: KernelParams,
+    kernel_params: "Kernel | KernelParams",
 ) -> jax.Array:
     """
     Spread nonuniform point values to a 1D uniform grid.
@@ -835,7 +843,7 @@ def interp_1d(
     x: jax.Array,
     fw: jax.Array,
     nf: int,
-    kernel_params: KernelParams,
+    kernel_params: "Kernel | KernelParams",
 ) -> jax.Array:
     """
     Interpolate from 1D uniform grid to nonuniform points.
@@ -928,7 +936,7 @@ def spread_2d(
     c: jax.Array,
     nf1: int,
     nf2: int,
-    kernel_params: KernelParams,
+    kernel_params: "Kernel | KernelParams",
 ) -> jax.Array:
     """
     Spread nonuniform point values to a 2D uniform grid.
@@ -1026,7 +1034,7 @@ def interp_2d(
     fw: jax.Array,
     nf1: int,
     nf2: int,
-    kernel_params: KernelParams,
+    kernel_params: "Kernel | KernelParams",
 ) -> jax.Array:
     """
     Interpolate from 2D uniform grid to nonuniform points.
@@ -1130,7 +1138,7 @@ def spread_3d(
     nf1: int,
     nf2: int,
     nf3: int,
-    kernel_params: KernelParams,
+    kernel_params: "Kernel | KernelParams",
 ) -> jax.Array:
     """
     Spread nonuniform point values to a 3D uniform grid.
@@ -1245,7 +1253,7 @@ def interp_3d(
     nf1: int,
     nf2: int,
     nf3: int,
-    kernel_params: KernelParams,
+    kernel_params: "Kernel | KernelParams",
 ) -> jax.Array:
     """
     Interpolate from 3D uniform grid to nonuniform points.

--- a/nufftax/core/spread.py
+++ b/nufftax/core/spread.py
@@ -24,7 +24,11 @@ from .kernel import Kernel, KernelParams, es_kernel_spec
 # ============================================================================
 
 _HAS_PALLAS_GPU = False
+_PALLAS_INTERPRET = False
 try:
+    from .pallas_spread import (
+        INTERPRET as _PALLAS_INTERPRET,
+    )
     from .pallas_spread import (
         spread_1d_pallas,
         spread_2d_pallas,
@@ -54,13 +58,15 @@ _USE_PALLAS_SPREAD = _bool_env("NUFFTAX_PALLAS_BACKEND", True)
 def _use_pallas(x: jax.Array, c: jax.Array) -> bool:
     """Whether to route this spread to the Pallas kernels.
 
-    Requires the backend enabled (env var) and a GPU. The Pallas kernels compute
-    in float32, so only fully 32-bit inputs (float32 coordinates, complex64
+    Requires the backend enabled (env var) and a GPU — or interpret mode
+    (NUFFTAX_PALLAS_INTERPRET, testing only). The Pallas kernels compute in
+    float32, so only fully 32-bit inputs (float32 coordinates, complex64
     strengths) take the Pallas path; any 64-bit input (x64 / complex128) falls
     back to pure JAX, which both preserves accuracy and keeps dtypes consistent
     across the AD rules.
     """
-    return _USE_PALLAS_SPREAD and _HAS_PALLAS_GPU and x.dtype == jnp.float32 and c.dtype == jnp.complex64
+    available = _HAS_PALLAS_GPU or _PALLAS_INTERPRET
+    return _USE_PALLAS_SPREAD and available and x.dtype == jnp.float32 and c.dtype == jnp.complex64
 
 
 # ============================================================================
@@ -999,24 +1005,9 @@ def _spread_2d_grad_xy(x, y, c, g, nf1, nf2, kernel_params):
     x_scaled = fold_rescale(x, nf1)
     y_scaled = fold_rescale(y, nf2)
 
-    ns2 = nspread / 2.0
-    offsets = jnp.arange(nspread)
-    scale_x = nf1 / (2.0 * jnp.pi)
-    scale_y = nf2 / (2.0 * jnp.pi)
-
-    # X dimension (fused kernel + derivative computation)
-    i0_x = jnp.ceil(x_scaled - ns2).astype(jnp.int32)
-    indices_x = (i0_x[:, None] + offsets[None, :]) % nf1
-    z_x = (i0_x[:, None] + offsets[None, :]).astype(x.dtype) - x_scaled[:, None]
-    weights_x, dweights_x_raw = kernel.value_and_grad(z_x)
-    dweights_x = -dweights_x_raw * scale_x
-
-    # Y dimension (fused kernel + derivative computation)
-    i0_y = jnp.ceil(y_scaled - ns2).astype(jnp.int32)
-    indices_y = (i0_y[:, None] + offsets[None, :]) % nf2
-    z_y = (i0_y[:, None] + offsets[None, :]).astype(y.dtype) - y_scaled[:, None]
-    weights_y, dweights_y_raw = kernel.value_and_grad(z_y)
-    dweights_y = -dweights_y_raw * scale_y
+    # Per-dimension kernel weights and derivatives (shared 1D helper)
+    indices_x, weights_x, dweights_x = compute_kernel_weights_derivative_1d(x_scaled, nf1, kernel)
+    indices_y, weights_y, dweights_y = compute_kernel_weights_derivative_1d(y_scaled, nf2, kernel)
 
     # 2D indices
     indices_2d = indices_y[:, :, None] * nf1 + indices_x[:, None, :]
@@ -1096,24 +1087,9 @@ def _interp_2d_grad_xy(x, y, fw, g, nf1, nf2, kernel_params):
     x_scaled = fold_rescale(x, nf1)
     y_scaled = fold_rescale(y, nf2)
 
-    ns2 = nspread / 2.0
-    offsets = jnp.arange(nspread)
-    scale_x = nf1 / (2.0 * jnp.pi)
-    scale_y = nf2 / (2.0 * jnp.pi)
-
-    # X dimension (fused kernel + derivative computation)
-    i0_x = jnp.ceil(x_scaled - ns2).astype(jnp.int32)
-    indices_x = (i0_x[:, None] + offsets[None, :]) % nf1
-    z_x = (i0_x[:, None] + offsets[None, :]).astype(x.dtype) - x_scaled[:, None]
-    weights_x, dweights_x_raw = kernel.value_and_grad(z_x)
-    dweights_x = -dweights_x_raw * scale_x
-
-    # Y dimension (fused kernel + derivative computation)
-    i0_y = jnp.ceil(y_scaled - ns2).astype(jnp.int32)
-    indices_y = (i0_y[:, None] + offsets[None, :]) % nf2
-    z_y = (i0_y[:, None] + offsets[None, :]).astype(y.dtype) - y_scaled[:, None]
-    weights_y, dweights_y_raw = kernel.value_and_grad(z_y)
-    dweights_y = -dweights_y_raw * scale_y
+    # Per-dimension kernel weights and derivatives (shared 1D helper)
+    indices_x, weights_x, dweights_x = compute_kernel_weights_derivative_1d(x_scaled, nf1, kernel)
+    indices_y, weights_y, dweights_y = compute_kernel_weights_derivative_1d(y_scaled, nf2, kernel)
 
     # 2D indices
     indices_2d = indices_y[:, :, None] * nf1 + indices_x[:, None, :]
@@ -1200,32 +1176,10 @@ def _spread_3d_grad_xyz(x, y, z, c, g, nf1, nf2, nf3, kernel_params):
     y_scaled = fold_rescale(y, nf2)
     z_scaled = fold_rescale(z, nf3)
 
-    ns2 = nspread / 2.0
-    offsets = jnp.arange(nspread)
-    scale_x = nf1 / (2.0 * jnp.pi)
-    scale_y = nf2 / (2.0 * jnp.pi)
-    scale_z = nf3 / (2.0 * jnp.pi)
-
-    # X dimension (fused kernel + derivative computation)
-    i0_x = jnp.ceil(x_scaled - ns2).astype(jnp.int32)
-    indices_x = (i0_x[:, None] + offsets[None, :]) % nf1
-    z_x = (i0_x[:, None] + offsets[None, :]).astype(x.dtype) - x_scaled[:, None]
-    weights_x, dweights_x_raw = kernel.value_and_grad(z_x)
-    dweights_x = -dweights_x_raw * scale_x
-
-    # Y dimension (fused kernel + derivative computation)
-    i0_y = jnp.ceil(y_scaled - ns2).astype(jnp.int32)
-    indices_y = (i0_y[:, None] + offsets[None, :]) % nf2
-    z_y = (i0_y[:, None] + offsets[None, :]).astype(y.dtype) - y_scaled[:, None]
-    weights_y, dweights_y_raw = kernel.value_and_grad(z_y)
-    dweights_y = -dweights_y_raw * scale_y
-
-    # Z dimension (fused kernel + derivative computation)
-    i0_z = jnp.ceil(z_scaled - ns2).astype(jnp.int32)
-    indices_z = (i0_z[:, None] + offsets[None, :]) % nf3
-    z_z = (i0_z[:, None] + offsets[None, :]).astype(z.dtype) - z_scaled[:, None]
-    weights_z, dweights_z_raw = kernel.value_and_grad(z_z)
-    dweights_z = -dweights_z_raw * scale_z
+    # Per-dimension kernel weights and derivatives (shared 1D helper)
+    indices_x, weights_x, dweights_x = compute_kernel_weights_derivative_1d(x_scaled, nf1, kernel)
+    indices_y, weights_y, dweights_y = compute_kernel_weights_derivative_1d(y_scaled, nf2, kernel)
+    indices_z, weights_z, dweights_z = compute_kernel_weights_derivative_1d(z_scaled, nf3, kernel)
 
     # 3D indices
     indices_3d = (
@@ -1315,32 +1269,10 @@ def _interp_3d_grad_xyz(x, y, z, fw, g, nf1, nf2, nf3, kernel_params):
     y_scaled = fold_rescale(y, nf2)
     z_scaled = fold_rescale(z, nf3)
 
-    ns2 = nspread / 2.0
-    offsets = jnp.arange(nspread)
-    scale_x = nf1 / (2.0 * jnp.pi)
-    scale_y = nf2 / (2.0 * jnp.pi)
-    scale_z = nf3 / (2.0 * jnp.pi)
-
-    # X dimension (fused kernel + derivative computation)
-    i0_x = jnp.ceil(x_scaled - ns2).astype(jnp.int32)
-    indices_x = (i0_x[:, None] + offsets[None, :]) % nf1
-    z_x = (i0_x[:, None] + offsets[None, :]).astype(x.dtype) - x_scaled[:, None]
-    weights_x, dweights_x_raw = kernel.value_and_grad(z_x)
-    dweights_x = -dweights_x_raw * scale_x
-
-    # Y dimension (fused kernel + derivative computation)
-    i0_y = jnp.ceil(y_scaled - ns2).astype(jnp.int32)
-    indices_y = (i0_y[:, None] + offsets[None, :]) % nf2
-    z_y = (i0_y[:, None] + offsets[None, :]).astype(y.dtype) - y_scaled[:, None]
-    weights_y, dweights_y_raw = kernel.value_and_grad(z_y)
-    dweights_y = -dweights_y_raw * scale_y
-
-    # Z dimension (fused kernel + derivative computation)
-    i0_z = jnp.ceil(z_scaled - ns2).astype(jnp.int32)
-    indices_z = (i0_z[:, None] + offsets[None, :]) % nf3
-    z_z = (i0_z[:, None] + offsets[None, :]).astype(z.dtype) - z_scaled[:, None]
-    weights_z, dweights_z_raw = kernel.value_and_grad(z_z)
-    dweights_z = -dweights_z_raw * scale_z
+    # Per-dimension kernel weights and derivatives (shared 1D helper)
+    indices_x, weights_x, dweights_x = compute_kernel_weights_derivative_1d(x_scaled, nf1, kernel)
+    indices_y, weights_y, dweights_y = compute_kernel_weights_derivative_1d(y_scaled, nf2, kernel)
+    indices_z, weights_z, dweights_z = compute_kernel_weights_derivative_1d(z_scaled, nf3, kernel)
 
     # 3D indices
     indices_3d = (

--- a/nufftax/transforms/autodiff.py
+++ b/nufftax/transforms/autodiff.py
@@ -18,17 +18,41 @@ from jax import Array
 from . import primitives as P
 
 
+def _split_upsampfac(upsampfac: "float | tuple[float, float]") -> tuple[float, float]:
+    """Normalize ``upsampfac`` to ``(forward, backward)``.
+
+    A scalar applies to both the forward transform and its adjoint (used in
+    reverse-mode AD); a ``(forward, backward)`` pair sets them independently —
+    the Type 1 / Type 2 oversampling need not match.
+    """
+    if isinstance(upsampfac, (tuple, list)):
+        return float(upsampfac[0]), float(upsampfac[1])
+    return float(upsampfac), float(upsampfac)
+
+
 # ============================================================================
 # Type 1 (nonuniform -> uniform)
 # ============================================================================
 
 
-def nufft1d1(x: Array, c: Array, n_modes: int, eps: float = 1e-6, isign: int = 1) -> Array:
-    return P.nufft1d1_p.bind(x, c, n_modes=n_modes, eps=eps, isign=isign)
+def nufft1d1(
+    x: Array, c: Array, n_modes: int, eps: float = 1e-6, isign: int = 1, upsampfac: "float | tuple[float, float]" = 2.0
+) -> Array:
+    uf, uf_t = _split_upsampfac(upsampfac)
+    return P.nufft1d1_p.bind(x, c, n_modes=n_modes, eps=eps, isign=isign, upsampfac=uf, upsampfac_T=uf_t)
 
 
-def nufft2d1(x: Array, y: Array, c: Array, n_modes: tuple[int, int], eps: float = 1e-6, isign: int = 1) -> Array:
-    return P.nufft2d1_p.bind(x, y, c, n_modes=tuple(n_modes), eps=eps, isign=isign)
+def nufft2d1(
+    x: Array,
+    y: Array,
+    c: Array,
+    n_modes: tuple[int, int],
+    eps: float = 1e-6,
+    isign: int = 1,
+    upsampfac: "float | tuple[float, float]" = 2.0,
+) -> Array:
+    uf, uf_t = _split_upsampfac(upsampfac)
+    return P.nufft2d1_p.bind(x, y, c, n_modes=tuple(n_modes), eps=eps, isign=isign, upsampfac=uf, upsampfac_T=uf_t)
 
 
 def nufft3d1(
@@ -39,8 +63,10 @@ def nufft3d1(
     n_modes: tuple[int, int, int],
     eps: float = 1e-6,
     isign: int = 1,
+    upsampfac: "float | tuple[float, float]" = 2.0,
 ) -> Array:
-    return P.nufft3d1_p.bind(x, y, z, c, n_modes=tuple(n_modes), eps=eps, isign=isign)
+    uf, uf_t = _split_upsampfac(upsampfac)
+    return P.nufft3d1_p.bind(x, y, z, c, n_modes=tuple(n_modes), eps=eps, isign=isign, upsampfac=uf, upsampfac_T=uf_t)
 
 
 # ============================================================================
@@ -48,16 +74,31 @@ def nufft3d1(
 # ============================================================================
 
 
-def nufft1d2(x: Array, f: Array, eps: float = 1e-6, isign: int = -1) -> Array:
-    return P.nufft1d2_p.bind(x, f, eps=eps, isign=isign)
+def nufft1d2(
+    x: Array, f: Array, eps: float = 1e-6, isign: int = -1, upsampfac: "float | tuple[float, float]" = 2.0
+) -> Array:
+    uf, uf_t = _split_upsampfac(upsampfac)
+    return P.nufft1d2_p.bind(x, f, eps=eps, isign=isign, upsampfac=uf, upsampfac_T=uf_t)
 
 
-def nufft2d2(x: Array, y: Array, f: Array, eps: float = 1e-6, isign: int = -1) -> Array:
-    return P.nufft2d2_p.bind(x, y, f, eps=eps, isign=isign)
+def nufft2d2(
+    x: Array, y: Array, f: Array, eps: float = 1e-6, isign: int = -1, upsampfac: "float | tuple[float, float]" = 2.0
+) -> Array:
+    uf, uf_t = _split_upsampfac(upsampfac)
+    return P.nufft2d2_p.bind(x, y, f, eps=eps, isign=isign, upsampfac=uf, upsampfac_T=uf_t)
 
 
-def nufft3d2(x: Array, y: Array, z: Array, f: Array, eps: float = 1e-6, isign: int = -1) -> Array:
-    return P.nufft3d2_p.bind(x, y, z, f, eps=eps, isign=isign)
+def nufft3d2(
+    x: Array,
+    y: Array,
+    z: Array,
+    f: Array,
+    eps: float = 1e-6,
+    isign: int = -1,
+    upsampfac: "float | tuple[float, float]" = 2.0,
+) -> Array:
+    uf, uf_t = _split_upsampfac(upsampfac)
+    return P.nufft3d2_p.bind(x, y, z, f, eps=eps, isign=isign, upsampfac=uf, upsampfac_T=uf_t)
 
 
 # ============================================================================

--- a/nufftax/transforms/nufft2.py
+++ b/nufftax/transforms/nufft2.py
@@ -59,8 +59,11 @@ def nufft1d2(
     # Compute fine grid size
     nf = compute_grid_size(n_modes, upsampfac, nspread)
 
+    # Infer dtype from input (use real part dtype of f)
+    dtype = jnp.real(f).dtype
+
     # Compute kernel Fourier series coefficients
-    phihat = kernel_fourier_series(nf, nspread, kernel_params.beta, kernel_params.c)
+    phihat = kernel_fourier_series(nf, nspread, kernel_params.beta, kernel_params.c, dtype=dtype)
 
     # Step 1: Deconvolve and pad to fine grid
     fw_hat = deconvolve_pad_1d(f, phihat, nf, modeord)
@@ -123,9 +126,12 @@ def nufft2d2(
     nf1 = compute_grid_size(n_modes1, upsampfac, nspread)
     nf2 = compute_grid_size(n_modes2, upsampfac, nspread)
 
+    # Infer dtype from input (use real part dtype of f)
+    dtype = jnp.real(f).dtype
+
     # Compute kernel Fourier series for each dimension
-    phihat1 = kernel_fourier_series(nf1, nspread, kernel_params.beta, kernel_params.c)
-    phihat2 = kernel_fourier_series(nf2, nspread, kernel_params.beta, kernel_params.c)
+    phihat1 = kernel_fourier_series(nf1, nspread, kernel_params.beta, kernel_params.c, dtype=dtype)
+    phihat2 = kernel_fourier_series(nf2, nspread, kernel_params.beta, kernel_params.c, dtype=dtype)
 
     # Step 1: Deconvolve and pad to fine grid
     fw_hat = deconvolve_pad_2d(f, phihat1, phihat2, nf1, nf2, modeord)
@@ -190,10 +196,13 @@ def nufft3d2(
     nf2 = compute_grid_size(n_modes2, upsampfac, nspread)
     nf3 = compute_grid_size(n_modes3, upsampfac, nspread)
 
+    # Infer dtype from input (use real part dtype of f)
+    dtype = jnp.real(f).dtype
+
     # Compute kernel Fourier series for each dimension
-    phihat1 = kernel_fourier_series(nf1, nspread, kernel_params.beta, kernel_params.c)
-    phihat2 = kernel_fourier_series(nf2, nspread, kernel_params.beta, kernel_params.c)
-    phihat3 = kernel_fourier_series(nf3, nspread, kernel_params.beta, kernel_params.c)
+    phihat1 = kernel_fourier_series(nf1, nspread, kernel_params.beta, kernel_params.c, dtype=dtype)
+    phihat2 = kernel_fourier_series(nf2, nspread, kernel_params.beta, kernel_params.c, dtype=dtype)
+    phihat3 = kernel_fourier_series(nf3, nspread, kernel_params.beta, kernel_params.c, dtype=dtype)
 
     # Step 1: Deconvolve and pad to fine grid
     fw_hat = deconvolve_pad_3d(f, phihat1, phihat2, phihat3, nf1, nf2, nf3, modeord)

--- a/nufftax/transforms/primitives.py
+++ b/nufftax/transforms/primitives.py
@@ -77,32 +77,35 @@ def _register(prim, impl_fn, aval_fn, jvp_fn, transpose_fn, source_idx):
 nufft1d1_p = Primitive("nufft1d1")
 
 
-def _impl_1d1(x, c, *, n_modes, eps, isign):
-    return _f1.nufft1d1(x, c, n_modes, eps, isign)
+def _impl_1d1(x, c, *, n_modes, eps, isign, upsampfac, upsampfac_T):
+    return _f1.nufft1d1(x, c, n_modes, eps, isign, upsampfac=upsampfac)
 
 
-def _aval_1d1(x, c, *, n_modes, eps, isign):
+def _aval_1d1(x, c, *, n_modes, eps, isign, upsampfac, upsampfac_T):
     return jax.core.ShapedArray(c.shape[:-1] + (n_modes,), c.dtype)
 
 
-def _jvp_1d1(primals, tangents, *, n_modes, eps, isign):
+def _jvp_1d1(primals, tangents, *, n_modes, eps, isign, upsampfac, upsampfac_T):
     x, c = primals
     dx, dc = tangents
-    f = nufft1d1_p.bind(x, c, n_modes=n_modes, eps=eps, isign=isign)
+    kw = {"n_modes": n_modes, "eps": eps, "isign": isign, "upsampfac": upsampfac, "upsampfac_T": upsampfac_T}
+    f = nufft1d1_p.bind(x, c, **kw)
 
     out = []
     if not isinstance(dc, ad.Zero):
-        out.append(nufft1d1_p.bind(x, dc, n_modes=n_modes, eps=eps, isign=isign))
+        out.append(nufft1d1_p.bind(x, dc, **kw))
     if not isinstance(dx, ad.Zero):
         k = jnp.arange(-(n_modes // 2), (n_modes + 1) // 2)
-        t = nufft1d1_p.bind(x, c * dx, n_modes=n_modes, eps=eps, isign=isign)
+        t = nufft1d1_p.bind(x, c * dx, **kw)
         out.append(1j * isign * k * t)
     return f, _sum_tangents(out, f)
 
 
-def _transpose_1d1(cot, x, c, *, n_modes, eps, isign):
+def _transpose_1d1(cot, x, c, *, n_modes, eps, isign, upsampfac, upsampfac_T):
     assert ad.is_undefined_primal(c)
-    cot_c = nufft1d2_p.bind(x, cot, eps=eps, isign=isign)
+    # Adjoint (Type 2) uses the backward upsampfac; swap so a second transpose
+    # returns to the forward value.
+    cot_c = nufft1d2_p.bind(x, cot, eps=eps, isign=isign, upsampfac=upsampfac_T, upsampfac_T=upsampfac)
     return (None, cot_c)
 
 
@@ -113,35 +116,38 @@ def _transpose_1d1(cot, x, c, *, n_modes, eps, isign):
 nufft1d2_p = Primitive("nufft1d2")
 
 
-def _impl_1d2(x, f, *, eps, isign):
-    return _f2.nufft1d2(x, f, eps, isign)
+def _impl_1d2(x, f, *, eps, isign, upsampfac, upsampfac_T):
+    return _f2.nufft1d2(x, f, eps, isign, upsampfac=upsampfac)
 
 
-def _aval_1d2(x, f, *, eps, isign):
+def _aval_1d2(x, f, *, eps, isign, upsampfac, upsampfac_T):
     return jax.core.ShapedArray(f.shape[:-1] + (x.shape[0],), f.dtype)
 
 
-def _jvp_1d2(primals, tangents, *, eps, isign):
+def _jvp_1d2(primals, tangents, *, eps, isign, upsampfac, upsampfac_T):
     x, f = primals
     dx, df = tangents
     n_modes = f.shape[-1]
-    c = nufft1d2_p.bind(x, f, eps=eps, isign=isign)
+    kw = {"eps": eps, "isign": isign, "upsampfac": upsampfac, "upsampfac_T": upsampfac_T}
+    c = nufft1d2_p.bind(x, f, **kw)
 
     out = []
     if not isinstance(df, ad.Zero):
-        out.append(nufft1d2_p.bind(x, df, eps=eps, isign=isign))
+        out.append(nufft1d2_p.bind(x, df, **kw))
     if not isinstance(dx, ad.Zero):
         k = jnp.arange(-(n_modes // 2), (n_modes + 1) // 2)
         kf = k * f
-        t = nufft1d2_p.bind(x, kf, eps=eps, isign=isign)
+        t = nufft1d2_p.bind(x, kf, **kw)
         out.append(1j * isign * dx * t)
     return c, _sum_tangents(out, c)
 
 
-def _transpose_1d2(cot, x, f, *, eps, isign):
+def _transpose_1d2(cot, x, f, *, eps, isign, upsampfac, upsampfac_T):
     assert ad.is_undefined_primal(f)
     n_modes = f.aval.shape[-1]
-    cot_f = nufft1d1_p.bind(x, cot, n_modes=n_modes, eps=eps, isign=isign)
+    cot_f = nufft1d1_p.bind(
+        x, cot, n_modes=n_modes, eps=eps, isign=isign, upsampfac=upsampfac_T, upsampfac_T=upsampfac
+    )
     return (None, cot_f)
 
 
@@ -152,38 +158,39 @@ def _transpose_1d2(cot, x, f, *, eps, isign):
 nufft2d1_p = Primitive("nufft2d1")
 
 
-def _impl_2d1(x, y, c, *, n_modes, eps, isign):
-    return _f1.nufft2d1(x, y, c, n_modes, eps, isign)
+def _impl_2d1(x, y, c, *, n_modes, eps, isign, upsampfac, upsampfac_T):
+    return _f1.nufft2d1(x, y, c, n_modes, eps, isign, upsampfac=upsampfac)
 
 
-def _aval_2d1(x, y, c, *, n_modes, eps, isign):
+def _aval_2d1(x, y, c, *, n_modes, eps, isign, upsampfac, upsampfac_T):
     n1, n2 = n_modes
     return jax.core.ShapedArray(c.shape[:-1] + (n2, n1), c.dtype)
 
 
-def _jvp_2d1(primals, tangents, *, n_modes, eps, isign):
+def _jvp_2d1(primals, tangents, *, n_modes, eps, isign, upsampfac, upsampfac_T):
     x, y, c = primals
     dx, dy, dc = tangents
     n1, n2 = n_modes
-    f = nufft2d1_p.bind(x, y, c, n_modes=n_modes, eps=eps, isign=isign)
+    kw = {"n_modes": n_modes, "eps": eps, "isign": isign, "upsampfac": upsampfac, "upsampfac_T": upsampfac_T}
+    f = nufft2d1_p.bind(x, y, c, **kw)
 
     out = []
     if not isinstance(dc, ad.Zero):
-        out.append(nufft2d1_p.bind(x, y, dc, n_modes=n_modes, eps=eps, isign=isign))
+        out.append(nufft2d1_p.bind(x, y, dc, **kw))
     if not isinstance(dx, ad.Zero):
         k1 = jnp.arange(-(n1 // 2), (n1 + 1) // 2)
-        t = nufft2d1_p.bind(x, y, c * dx, n_modes=n_modes, eps=eps, isign=isign)
+        t = nufft2d1_p.bind(x, y, c * dx, **kw)
         out.append(1j * isign * k1[None, :] * t)
     if not isinstance(dy, ad.Zero):
         k2 = jnp.arange(-(n2 // 2), (n2 + 1) // 2)
-        t = nufft2d1_p.bind(x, y, c * dy, n_modes=n_modes, eps=eps, isign=isign)
+        t = nufft2d1_p.bind(x, y, c * dy, **kw)
         out.append(1j * isign * k2[:, None] * t)
     return f, _sum_tangents(out, f)
 
 
-def _transpose_2d1(cot, x, y, c, *, n_modes, eps, isign):
+def _transpose_2d1(cot, x, y, c, *, n_modes, eps, isign, upsampfac, upsampfac_T):
     assert ad.is_undefined_primal(c)
-    cot_c = nufft2d2_p.bind(x, y, cot, eps=eps, isign=isign)
+    cot_c = nufft2d2_p.bind(x, y, cot, eps=eps, isign=isign, upsampfac=upsampfac_T, upsampfac_T=upsampfac)
     return (None, None, cot_c)
 
 
@@ -194,40 +201,43 @@ def _transpose_2d1(cot, x, y, c, *, n_modes, eps, isign):
 nufft2d2_p = Primitive("nufft2d2")
 
 
-def _impl_2d2(x, y, f, *, eps, isign):
-    return _f2.nufft2d2(x, y, f, eps, isign)
+def _impl_2d2(x, y, f, *, eps, isign, upsampfac, upsampfac_T):
+    return _f2.nufft2d2(x, y, f, eps, isign, upsampfac=upsampfac)
 
 
-def _aval_2d2(x, y, f, *, eps, isign):
+def _aval_2d2(x, y, f, *, eps, isign, upsampfac, upsampfac_T):
     return jax.core.ShapedArray(f.shape[:-2] + (x.shape[0],), f.dtype)
 
 
-def _jvp_2d2(primals, tangents, *, eps, isign):
+def _jvp_2d2(primals, tangents, *, eps, isign, upsampfac, upsampfac_T):
     x, y, f = primals
     dx, dy, df = tangents
     n2, n1 = f.shape[-2:]
-    c = nufft2d2_p.bind(x, y, f, eps=eps, isign=isign)
+    kw = {"eps": eps, "isign": isign, "upsampfac": upsampfac, "upsampfac_T": upsampfac_T}
+    c = nufft2d2_p.bind(x, y, f, **kw)
 
     out = []
     if not isinstance(df, ad.Zero):
-        out.append(nufft2d2_p.bind(x, y, df, eps=eps, isign=isign))
+        out.append(nufft2d2_p.bind(x, y, df, **kw))
     if not isinstance(dx, ad.Zero):
         k1 = jnp.arange(-(n1 // 2), (n1 + 1) // 2)
         k1_f = f * k1[None, :]
-        t = nufft2d2_p.bind(x, y, k1_f, eps=eps, isign=isign)
+        t = nufft2d2_p.bind(x, y, k1_f, **kw)
         out.append(1j * isign * dx * t)
     if not isinstance(dy, ad.Zero):
         k2 = jnp.arange(-(n2 // 2), (n2 + 1) // 2)
         k2_f = f * k2[:, None]
-        t = nufft2d2_p.bind(x, y, k2_f, eps=eps, isign=isign)
+        t = nufft2d2_p.bind(x, y, k2_f, **kw)
         out.append(1j * isign * dy * t)
     return c, _sum_tangents(out, c)
 
 
-def _transpose_2d2(cot, x, y, f, *, eps, isign):
+def _transpose_2d2(cot, x, y, f, *, eps, isign, upsampfac, upsampfac_T):
     assert ad.is_undefined_primal(f)
     n2, n1 = f.aval.shape[-2:]
-    cot_f = nufft2d1_p.bind(x, y, cot, n_modes=(n1, n2), eps=eps, isign=isign)
+    cot_f = nufft2d1_p.bind(
+        x, y, cot, n_modes=(n1, n2), eps=eps, isign=isign, upsampfac=upsampfac_T, upsampfac_T=upsampfac
+    )
     return (None, None, cot_f)
 
 
@@ -238,42 +248,43 @@ def _transpose_2d2(cot, x, y, f, *, eps, isign):
 nufft3d1_p = Primitive("nufft3d1")
 
 
-def _impl_3d1(x, y, z, c, *, n_modes, eps, isign):
-    return _f1.nufft3d1(x, y, z, c, n_modes, eps, isign)
+def _impl_3d1(x, y, z, c, *, n_modes, eps, isign, upsampfac, upsampfac_T):
+    return _f1.nufft3d1(x, y, z, c, n_modes, eps, isign, upsampfac=upsampfac)
 
 
-def _aval_3d1(x, y, z, c, *, n_modes, eps, isign):
+def _aval_3d1(x, y, z, c, *, n_modes, eps, isign, upsampfac, upsampfac_T):
     n1, n2, n3 = n_modes
     return jax.core.ShapedArray(c.shape[:-1] + (n3, n2, n1), c.dtype)
 
 
-def _jvp_3d1(primals, tangents, *, n_modes, eps, isign):
+def _jvp_3d1(primals, tangents, *, n_modes, eps, isign, upsampfac, upsampfac_T):
     x, y, z, c = primals
     dx, dy, dz, dc = tangents
     n1, n2, n3 = n_modes
-    f = nufft3d1_p.bind(x, y, z, c, n_modes=n_modes, eps=eps, isign=isign)
+    kw = {"n_modes": n_modes, "eps": eps, "isign": isign, "upsampfac": upsampfac, "upsampfac_T": upsampfac_T}
+    f = nufft3d1_p.bind(x, y, z, c, **kw)
 
     out = []
     if not isinstance(dc, ad.Zero):
-        out.append(nufft3d1_p.bind(x, y, z, dc, n_modes=n_modes, eps=eps, isign=isign))
+        out.append(nufft3d1_p.bind(x, y, z, dc, **kw))
     if not isinstance(dx, ad.Zero):
         k1 = jnp.arange(-(n1 // 2), (n1 + 1) // 2)
-        t = nufft3d1_p.bind(x, y, z, c * dx, n_modes=n_modes, eps=eps, isign=isign)
+        t = nufft3d1_p.bind(x, y, z, c * dx, **kw)
         out.append(1j * isign * k1[None, None, :] * t)
     if not isinstance(dy, ad.Zero):
         k2 = jnp.arange(-(n2 // 2), (n2 + 1) // 2)
-        t = nufft3d1_p.bind(x, y, z, c * dy, n_modes=n_modes, eps=eps, isign=isign)
+        t = nufft3d1_p.bind(x, y, z, c * dy, **kw)
         out.append(1j * isign * k2[None, :, None] * t)
     if not isinstance(dz, ad.Zero):
         k3 = jnp.arange(-(n3 // 2), (n3 + 1) // 2)
-        t = nufft3d1_p.bind(x, y, z, c * dz, n_modes=n_modes, eps=eps, isign=isign)
+        t = nufft3d1_p.bind(x, y, z, c * dz, **kw)
         out.append(1j * isign * k3[:, None, None] * t)
     return f, _sum_tangents(out, f)
 
 
-def _transpose_3d1(cot, x, y, z, c, *, n_modes, eps, isign):
+def _transpose_3d1(cot, x, y, z, c, *, n_modes, eps, isign, upsampfac, upsampfac_T):
     assert ad.is_undefined_primal(c)
-    cot_c = nufft3d2_p.bind(x, y, z, cot, eps=eps, isign=isign)
+    cot_c = nufft3d2_p.bind(x, y, z, cot, eps=eps, isign=isign, upsampfac=upsampfac_T, upsampfac_T=upsampfac)
     return (None, None, None, cot_c)
 
 
@@ -284,45 +295,48 @@ def _transpose_3d1(cot, x, y, z, c, *, n_modes, eps, isign):
 nufft3d2_p = Primitive("nufft3d2")
 
 
-def _impl_3d2(x, y, z, f, *, eps, isign):
-    return _f2.nufft3d2(x, y, z, f, eps, isign)
+def _impl_3d2(x, y, z, f, *, eps, isign, upsampfac, upsampfac_T):
+    return _f2.nufft3d2(x, y, z, f, eps, isign, upsampfac=upsampfac)
 
 
-def _aval_3d2(x, y, z, f, *, eps, isign):
+def _aval_3d2(x, y, z, f, *, eps, isign, upsampfac, upsampfac_T):
     return jax.core.ShapedArray(f.shape[:-3] + (x.shape[0],), f.dtype)
 
 
-def _jvp_3d2(primals, tangents, *, eps, isign):
+def _jvp_3d2(primals, tangents, *, eps, isign, upsampfac, upsampfac_T):
     x, y, z, f = primals
     dx, dy, dz, df = tangents
     n3, n2, n1 = f.shape[-3:]
-    c = nufft3d2_p.bind(x, y, z, f, eps=eps, isign=isign)
+    kw = {"eps": eps, "isign": isign, "upsampfac": upsampfac, "upsampfac_T": upsampfac_T}
+    c = nufft3d2_p.bind(x, y, z, f, **kw)
 
     out = []
     if not isinstance(df, ad.Zero):
-        out.append(nufft3d2_p.bind(x, y, z, df, eps=eps, isign=isign))
+        out.append(nufft3d2_p.bind(x, y, z, df, **kw))
     if not isinstance(dx, ad.Zero):
         k1 = jnp.arange(-(n1 // 2), (n1 + 1) // 2)
         k1_f = f * k1[None, None, :]
-        t = nufft3d2_p.bind(x, y, z, k1_f, eps=eps, isign=isign)
+        t = nufft3d2_p.bind(x, y, z, k1_f, **kw)
         out.append(1j * isign * dx * t)
     if not isinstance(dy, ad.Zero):
         k2 = jnp.arange(-(n2 // 2), (n2 + 1) // 2)
         k2_f = f * k2[None, :, None]
-        t = nufft3d2_p.bind(x, y, z, k2_f, eps=eps, isign=isign)
+        t = nufft3d2_p.bind(x, y, z, k2_f, **kw)
         out.append(1j * isign * dy * t)
     if not isinstance(dz, ad.Zero):
         k3 = jnp.arange(-(n3 // 2), (n3 + 1) // 2)
         k3_f = f * k3[:, None, None]
-        t = nufft3d2_p.bind(x, y, z, k3_f, eps=eps, isign=isign)
+        t = nufft3d2_p.bind(x, y, z, k3_f, **kw)
         out.append(1j * isign * dz * t)
     return c, _sum_tangents(out, c)
 
 
-def _transpose_3d2(cot, x, y, z, f, *, eps, isign):
+def _transpose_3d2(cot, x, y, z, f, *, eps, isign, upsampfac, upsampfac_T):
     assert ad.is_undefined_primal(f)
     n3, n2, n1 = f.aval.shape[-3:]
-    cot_f = nufft3d1_p.bind(x, y, z, cot, n_modes=(n1, n2, n3), eps=eps, isign=isign)
+    cot_f = nufft3d1_p.bind(
+        x, y, z, cot, n_modes=(n1, n2, n3), eps=eps, isign=isign, upsampfac=upsampfac_T, upsampfac_T=upsampfac
+    )
     return (None, None, None, cot_f)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,9 @@ Repository = "https://github.com/GragasLab/nufftax"
 where = ["."]
 include = ["nufftax*"]
 
+[tool.setuptools.package-data]
+nufftax = ["py.typed"]
+
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 python_files = ["test_*.py"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,7 @@ Pytest fixtures and utilities for JAX-FINUFFT tests.
 Provides common test fixtures, numerical utilities, and shared configuration.
 """
 
+import os
 from collections.abc import Callable
 
 import jax
@@ -15,6 +16,11 @@ import pytest
 # ============================================================================
 # Configuration
 # ============================================================================
+
+# The Pallas backend is opt-in (off by default). The test suite enables it so
+# the Pallas paths are exercised wherever they can run (GPU, or CPU with
+# NUFFTAX_PALLAS_INTERPRET=1). Must be set before nufftax is imported.
+os.environ.setdefault("NUFFTAX_PALLAS_BACKEND", "1")
 
 # The suite runs with float64 enabled: several tests need complex128 (Type 3
 # accuracy vs FINUFFT, dtype tests, high-precision adjoints). Enabling it here

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,6 +16,13 @@ import pytest
 # Configuration
 # ============================================================================
 
+# The suite runs with float64 enabled: several tests need complex128 (Type 3
+# accuracy vs FINUFFT, dtype tests, high-precision adjoints). Enabling it here
+# — conftest is imported before any test module — makes the configuration
+# deterministic. Previously it was an import side-effect of test_nufft3.py, so
+# running a subset of files behaved differently from the full suite.
+jax.config.update("jax_enable_x64", True)
+
 # Seed for reproducible tests
 DEFAULT_SEED = 42
 

--- a/tests/test_custom_kernel.py
+++ b/tests/test_custom_kernel.py
@@ -246,6 +246,24 @@ def test_autodiff_derivative_fallback_matches_analytic(rng):
 
 
 # ============================================================================
+# NUFFTAX_PALLAS_BACKEND env var gates the Pallas spreading backend (default on)
+# ============================================================================
+
+
+def test_pallas_backend_env_flag(monkeypatch):
+    from nufftax.core.spread import _bool_env
+
+    monkeypatch.delenv("NUFFTAX_PALLAS_BACKEND", raising=False)
+    assert _bool_env("NUFFTAX_PALLAS_BACKEND", True) is True  # default on
+    for off in ("0", "false", "False", "no", "off"):
+        monkeypatch.setenv("NUFFTAX_PALLAS_BACKEND", off)
+        assert _bool_env("NUFFTAX_PALLAS_BACKEND", True) is False
+    for on in ("1", "true", "yes", "on"):
+        monkeypatch.setenv("NUFFTAX_PALLAS_BACKEND", on)
+        assert _bool_env("NUFFTAX_PALLAS_BACKEND", True) is True
+
+
+# ============================================================================
 # GPU-only: the custom kernel runs through the Pallas spread kernels and
 # matches the pure-JAX reference (the point that a custom phi can be threaded
 # into Pallas, not just the built-in ES kernel).
@@ -295,12 +313,10 @@ class TestCustomKernelPallas:
 
     @gpu_only
     def test_public_dispatch_routes_custom_kernel_to_pallas(self):
-        # Above the dispatch threshold, spread_1d with a custom kernel must take
-        # the Pallas path and still match the pure-JAX reference.
-        from nufftax.core.spread import _PALLAS_MIN_M_SPREAD_1D
-
+        # With the Pallas backend enabled (default), spread_1d with a custom
+        # kernel must take the Pallas path and still match the pure-JAX reference.
         kernel = gaussian_kernel(NSPREAD, SIGMA)
-        (x,), c = _setup(max(_PALLAS_MIN_M_SPREAD_1D, 20_000), 1)
+        (x,), c = _setup(20_000, 1)
         out = spread_1d(x, c, 256, kernel)
         out_ref = spread_1d_impl(x, c, 256, kernel)
         np.testing.assert_allclose(np.asarray(out), np.asarray(out_ref), rtol=5e-4, atol=5e-5)

--- a/tests/test_custom_kernel.py
+++ b/tests/test_custom_kernel.py
@@ -246,6 +246,55 @@ def test_autodiff_derivative_fallback_matches_analytic(rng):
 
 
 # ============================================================================
+# Differentiability / vmap w.r.t. kernel parameters
+#
+# Kernel is a NamedTuple (pytree). Parameters baked into a closed-over phi are
+# differentiable when the kernel is built inside the transformed function and
+# the pure-JAX spread/interp path is used. (The public spread_* keep the kernel
+# as a static custom_vjp argument — the same as the built-in KernelParams — so
+# differentiating *through them* w.r.t. kernel parameters is not supported.)
+# ============================================================================
+
+
+def _gauss_kernel_from_sigma(sigma):
+    inv_2s2 = 1.0 / (2.0 * sigma * sigma)
+    return Kernel(nspread=NSPREAD, phi=lambda z: jnp.exp(-inv_2s2 * (z * z)))
+
+
+def test_grad_wrt_kernel_param_pure_jax_matches_fd(rng):
+    M, nf = 40, 64
+    x = jnp.asarray(rng.uniform(-np.pi, np.pi, M))
+    c = jnp.asarray(rng.standard_normal(M)).astype(jnp.complex64)
+    g = jnp.asarray(rng.standard_normal(nf))
+
+    def loss(sigma):
+        return jnp.sum(g * jnp.real(spread_1d_impl(x, c, nf, _gauss_kernel_from_sigma(sigma))))
+
+    sigma = jnp.float32(1.5)
+    grad = float(jax.grad(loss)(sigma))
+
+    eps = 1e-3
+    fd = (float(loss(sigma + eps)) - float(loss(sigma - eps))) / (2 * eps)
+    assert_allclose(grad, fd, rtol=2e-2, atol=2e-2)
+
+
+def test_vmap_over_kernel_param_pure_jax(rng):
+    M, nf = 30, 64
+    x = jnp.asarray(rng.uniform(-np.pi, np.pi, M))
+    c = jnp.asarray(rng.standard_normal(M)).astype(jnp.complex64)
+    sigmas = jnp.array([1.0, 1.5, 2.0], dtype=jnp.float32)
+
+    def spread_with(sigma):
+        return spread_1d_impl(x, c, nf, _gauss_kernel_from_sigma(sigma))
+
+    out = jax.vmap(spread_with)(sigmas)
+    assert out.shape == (3, nf)
+    # each slice equals the un-vmapped spread for that sigma
+    for i, s in enumerate(sigmas):
+        assert_allclose(np.asarray(out[i]), np.asarray(spread_with(s)), rtol=1e-5, atol=1e-5)
+
+
+# ============================================================================
 # NUFFTAX_PALLAS_BACKEND env var gates the Pallas spreading backend (default on)
 # ============================================================================
 

--- a/tests/test_custom_kernel.py
+++ b/tests/test_custom_kernel.py
@@ -295,7 +295,8 @@ def test_vmap_over_kernel_param_pure_jax(rng):
 
 
 # ============================================================================
-# NUFFTAX_PALLAS_BACKEND env var gates the Pallas spreading backend (default on)
+# NUFFTAX_PALLAS_BACKEND env var gates the Pallas spreading backend
+# (opt-in: defaults to off, pure JAX)
 # ============================================================================
 
 
@@ -303,13 +304,13 @@ def test_pallas_backend_env_flag(monkeypatch):
     from nufftax.core.spread import _bool_env
 
     monkeypatch.delenv("NUFFTAX_PALLAS_BACKEND", raising=False)
-    assert _bool_env("NUFFTAX_PALLAS_BACKEND", True) is True  # default on
+    assert _bool_env("NUFFTAX_PALLAS_BACKEND", False) is False  # opt-in: default off
     for off in ("0", "false", "False", "no", "off"):
         monkeypatch.setenv("NUFFTAX_PALLAS_BACKEND", off)
-        assert _bool_env("NUFFTAX_PALLAS_BACKEND", True) is False
+        assert _bool_env("NUFFTAX_PALLAS_BACKEND", False) is False
     for on in ("1", "true", "yes", "on"):
         monkeypatch.setenv("NUFFTAX_PALLAS_BACKEND", on)
-        assert _bool_env("NUFFTAX_PALLAS_BACKEND", True) is True
+        assert _bool_env("NUFFTAX_PALLAS_BACKEND", False) is True
 
 
 # ============================================================================

--- a/tests/test_custom_kernel.py
+++ b/tests/test_custom_kernel.py
@@ -1,0 +1,306 @@
+"""
+Tests for user-supplied custom spreading/interpolation kernels.
+
+Covers the ``Kernel`` abstraction that lets ``spread_*`` / ``interp_*`` use an
+arbitrary kernel (e.g. a Gaussian) instead of the built-in ES kernel:
+- the ES kernel routed through ``Kernel`` matches the ``KernelParams`` path,
+- a Gaussian kernel matches an independent direct reference,
+- gradients w.r.t. coordinates match finite differences,
+- spreading and interpolation are adjoints for the same kernel,
+- the autodiff derivative fallback matches an analytic ``phi_and_dphi``.
+"""
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+from numpy.testing import assert_allclose
+
+from nufftax.core import (
+    interp_1d,
+    spread_1d,
+    spread_2d,
+    spread_3d,
+)
+from nufftax.core.kernel import Kernel, compute_kernel_params, es_kernel_spec
+from nufftax.core.spread import spread_1d_impl, spread_2d_impl, spread_3d_impl
+
+
+NSPREAD = 10
+SIGMA = 1.5
+
+_HAS_GPU = any(d.platform == "gpu" for d in jax.devices())
+gpu_only = pytest.mark.skipif(not _HAS_GPU, reason="custom-kernel Pallas path requires a GPU")
+
+
+def gaussian_kernel(nspread, sigma):
+    """Truncated Gaussian Kernel ``phi(z) = exp(-z^2 / (2*sigma^2))`` for tests."""
+    inv_2s2 = 1.0 / (2.0 * sigma * sigma)
+    inv_s2 = 1.0 / (sigma * sigma)
+
+    def phi(z):
+        return jnp.exp(-inv_2s2 * (z * z))
+
+    def phi_and_dphi(z):
+        p = phi(z)
+        return p, -inv_s2 * z * p
+
+    return Kernel(nspread=nspread, phi=phi, phi_and_dphi=phi_and_dphi)
+
+
+@pytest.fixture
+def rng():
+    return np.random.default_rng(0)
+
+
+@pytest.fixture
+def kernel_params():
+    return compute_kernel_params(1e-6)
+
+
+# ============================================================================
+# Independent direct references (pure numpy)
+# ============================================================================
+
+
+def _fold_rescale(x, n):
+    r = x / (2.0 * np.pi) + 0.5
+    return (r - np.floor(r)) * n
+
+
+def _gauss(z, sigma):
+    return np.exp(-(z * z) / (2.0 * sigma * sigma))
+
+
+def spread_1d_gauss_direct(x, c, nf, nspread, sigma):
+    fw = np.zeros(nf, dtype=np.complex128)
+    xs = _fold_rescale(x, nf)
+    i0 = np.ceil(xs - nspread / 2.0).astype(np.int64)
+    for j in range(len(x)):
+        for k in range(nspread):
+            idx = (i0[j] + k) % nf
+            z = (i0[j] + k) - xs[j]
+            fw[idx] += c[j] * _gauss(z, sigma)
+    return fw
+
+
+def spread_2d_gauss_direct(x, y, c, nf1, nf2, nspread, sigma):
+    fw = np.zeros((nf2, nf1), dtype=np.complex128)
+    xs = _fold_rescale(x, nf1)
+    ys = _fold_rescale(y, nf2)
+    i0x = np.ceil(xs - nspread / 2.0).astype(np.int64)
+    i0y = np.ceil(ys - nspread / 2.0).astype(np.int64)
+    for j in range(len(x)):
+        for ky in range(nspread):
+            iy = (i0y[j] + ky) % nf2
+            wy = _gauss((i0y[j] + ky) - ys[j], sigma)
+            for kx in range(nspread):
+                ix = (i0x[j] + kx) % nf1
+                wx = _gauss((i0x[j] + kx) - xs[j], sigma)
+                fw[iy, ix] += c[j] * wy * wx
+    return fw
+
+
+# ============================================================================
+# ES kernel routed through Kernel matches the KernelParams path
+# ============================================================================
+
+
+def test_es_via_kernel_matches_kernelparams_1d(rng, kernel_params):
+    M, nf = 200, 128
+    x = jnp.asarray(rng.uniform(-np.pi, np.pi, M))
+    c = jnp.asarray(rng.standard_normal(M) + 1j * rng.standard_normal(M))
+
+    ref = spread_1d(x, c, nf, kernel_params)
+    via = spread_1d(x, c, nf, es_kernel_spec(kernel_params))
+    assert_allclose(np.asarray(via), np.asarray(ref), rtol=1e-6, atol=1e-6)
+
+
+def test_es_via_kernel_matches_kernelparams_2d(rng, kernel_params):
+    M, nf1, nf2 = 200, 64, 48
+    x = jnp.asarray(rng.uniform(-np.pi, np.pi, M))
+    y = jnp.asarray(rng.uniform(-np.pi, np.pi, M))
+    c = jnp.asarray(rng.standard_normal(M) + 1j * rng.standard_normal(M))
+
+    ref = spread_2d(x, y, c, nf1, nf2, kernel_params)
+    via = spread_2d(x, y, c, nf1, nf2, es_kernel_spec(kernel_params))
+    assert_allclose(np.asarray(via), np.asarray(ref), rtol=1e-6, atol=1e-6)
+
+
+# ============================================================================
+# Gaussian custom kernel matches direct reference
+# ============================================================================
+
+
+def test_gaussian_spread_1d_matches_direct(rng):
+    M, nf = 150, 100
+    x = jnp.asarray(rng.uniform(-np.pi, np.pi, M))
+    c = jnp.asarray(rng.standard_normal(M) + 1j * rng.standard_normal(M))
+    kernel = gaussian_kernel(NSPREAD, SIGMA)
+
+    out = np.asarray(spread_1d(x, c, nf, kernel))
+    ref = spread_1d_gauss_direct(np.asarray(x), np.asarray(c), nf, NSPREAD, SIGMA)
+    assert_allclose(out, ref, rtol=1e-5, atol=1e-5)
+
+
+def test_gaussian_spread_2d_matches_direct(rng):
+    M, nf1, nf2 = 120, 40, 32
+    x = jnp.asarray(rng.uniform(-np.pi, np.pi, M))
+    y = jnp.asarray(rng.uniform(-np.pi, np.pi, M))
+    c = jnp.asarray(rng.standard_normal(M) + 1j * rng.standard_normal(M))
+    kernel = gaussian_kernel(NSPREAD, SIGMA)
+
+    out = np.asarray(spread_2d(x, y, c, nf1, nf2, kernel))
+    ref = spread_2d_gauss_direct(np.asarray(x), np.asarray(y), np.asarray(c), nf1, nf2, NSPREAD, SIGMA)
+    assert_allclose(out, ref, rtol=1e-5, atol=1e-5)
+
+
+def test_gaussian_spread_3d_runs_and_is_finite(rng):
+    M, nf1, nf2, nf3 = 100, 24, 20, 16
+    x = jnp.asarray(rng.uniform(-np.pi, np.pi, M))
+    y = jnp.asarray(rng.uniform(-np.pi, np.pi, M))
+    z = jnp.asarray(rng.uniform(-np.pi, np.pi, M))
+    c = jnp.asarray(rng.standard_normal(M) + 1j * rng.standard_normal(M))
+    kernel = gaussian_kernel(NSPREAD, SIGMA)
+
+    out = spread_3d(x, y, z, c, nf1, nf2, nf3, kernel)
+    assert out.shape == (nf3, nf2, nf1)
+    assert np.all(np.isfinite(np.asarray(out).view(np.float64)))
+
+
+# ============================================================================
+# Spread / interp are adjoints for the same custom kernel
+# ============================================================================
+
+
+def test_custom_kernel_adjoint_1d(rng):
+    M, nf = 80, 64
+    x = jnp.asarray(rng.uniform(-np.pi, np.pi, M))
+    c = jnp.asarray(rng.standard_normal(M) + 1j * rng.standard_normal(M))
+    g = jnp.asarray(rng.standard_normal(nf) + 1j * rng.standard_normal(nf))
+    kernel = gaussian_kernel(NSPREAD, SIGMA)
+
+    # <g, spread(c)> == <interp(g), c>
+    lhs = np.vdot(np.asarray(g), np.asarray(spread_1d(x, c, nf, kernel)))
+    rhs = np.vdot(np.asarray(interp_1d(x, g, nf, kernel)), np.asarray(c))
+    assert_allclose(lhs, rhs, rtol=1e-5, atol=1e-5)
+
+
+# ============================================================================
+# Gradient w.r.t. coordinates matches finite differences
+# ============================================================================
+
+
+def test_custom_kernel_grad_x_1d_finite_difference(rng):
+    # Real inputs avoid the complex-cotangent convention ambiguity so the
+    # gradient can be compared directly against central finite differences.
+    M, nf = 30, 64
+    x = jnp.asarray(rng.uniform(-2.0, 2.0, M))
+    c = jnp.asarray(rng.standard_normal(M)).astype(jnp.complex64)
+    g = jnp.asarray(rng.standard_normal(nf))
+    kernel = gaussian_kernel(NSPREAD, SIGMA)
+
+    def loss(xv):
+        return jnp.sum(g * jnp.real(spread_1d(xv, c, nf, kernel)))
+
+    grad = np.asarray(jax.grad(loss)(x))
+
+    eps = 1e-4
+    fd = np.zeros(M)
+    x_np = np.asarray(x)
+    for j in range(M):
+        xp = x_np.copy()
+        xp[j] += eps
+        xm = x_np.copy()
+        xm[j] -= eps
+        fd[j] = (float(loss(jnp.asarray(xp))) - float(loss(jnp.asarray(xm)))) / (2 * eps)
+
+    assert_allclose(grad, fd, rtol=2e-2, atol=1e-1)
+
+
+# ============================================================================
+# Autodiff derivative fallback matches an analytic phi_and_dphi
+# ============================================================================
+
+
+def test_autodiff_derivative_fallback_matches_analytic(rng):
+    M, nf = 30, 64
+    x = jnp.asarray(rng.uniform(-2.0, 2.0, M))
+    c = jnp.asarray(rng.standard_normal(M) + 1j * rng.standard_normal(M))
+    g = jnp.asarray(rng.standard_normal(nf) + 1j * rng.standard_normal(nf))
+
+    inv_2s2 = 1.0 / (2.0 * SIGMA * SIGMA)
+
+    def phi(zz):
+        return jnp.exp(-inv_2s2 * (zz * zz))
+
+    analytic = gaussian_kernel(NSPREAD, SIGMA)  # has phi_and_dphi
+    autodiff = Kernel(nspread=NSPREAD, phi=phi)  # derivative via autodiff
+
+    def loss(kernel, xv):
+        return jnp.real(jnp.vdot(g, spread_1d(xv, c, nf, kernel)))
+
+    grad_analytic = np.asarray(jax.grad(lambda xv: loss(analytic, xv))(x))
+    grad_autodiff = np.asarray(jax.grad(lambda xv: loss(autodiff, xv))(x))
+    assert_allclose(grad_autodiff, grad_analytic, rtol=1e-5, atol=1e-6)
+
+
+# ============================================================================
+# GPU-only: the custom kernel runs through the Pallas spread kernels and
+# matches the pure-JAX reference (the point that a custom phi can be threaded
+# into Pallas, not just the built-in ES kernel).
+# ============================================================================
+
+
+def _setup(M, ndim, seed=0):
+    key = jax.random.PRNGKey(seed)
+    keys = jax.random.split(key, ndim + 2)
+    coords = [
+        jax.random.uniform(keys[i], (M,), minval=-jnp.pi, maxval=jnp.pi).astype(jnp.float32) for i in range(ndim)
+    ]
+    c = (jax.random.normal(keys[-2], (M,)) + 1j * jax.random.normal(keys[-1], (M,))).astype(jnp.complex64)
+    return coords, c
+
+
+class TestCustomKernelPallas:
+    @gpu_only
+    def test_pallas_1d_matches_pure_jax(self):
+        from nufftax.core.pallas_spread import spread_1d_pallas
+
+        kernel = gaussian_kernel(NSPREAD, SIGMA)
+        (x,), c = _setup(20_000, 1)
+        out_pallas = spread_1d_pallas(x, c, 256, kernel)
+        out_ref = spread_1d_impl(x, c, 256, kernel)
+        np.testing.assert_allclose(np.asarray(out_pallas), np.asarray(out_ref), rtol=5e-4, atol=5e-5)
+
+    @gpu_only
+    def test_pallas_2d_matches_pure_jax(self):
+        from nufftax.core.pallas_spread import spread_2d_pallas
+
+        kernel = gaussian_kernel(NSPREAD, SIGMA)
+        (x, y), c = _setup(20_000, 2)
+        out_pallas = spread_2d_pallas(x, y, c, 64, 48, kernel)
+        out_ref = spread_2d_impl(x, y, c, 64, 48, kernel)
+        np.testing.assert_allclose(np.asarray(out_pallas), np.asarray(out_ref), rtol=5e-4, atol=5e-5)
+
+    @gpu_only
+    def test_pallas_3d_matches_pure_jax(self):
+        from nufftax.core.pallas_spread import spread_3d_pallas
+
+        kernel = gaussian_kernel(NSPREAD, SIGMA)
+        (x, y, z), c = _setup(20_000, 3)
+        out_pallas = spread_3d_pallas(x, y, z, c, 24, 20, 16, kernel)
+        out_ref = spread_3d_impl(x, y, z, c, 24, 20, 16, kernel)
+        np.testing.assert_allclose(np.asarray(out_pallas), np.asarray(out_ref), rtol=5e-4, atol=5e-5)
+
+    @gpu_only
+    def test_public_dispatch_routes_custom_kernel_to_pallas(self):
+        # Above the dispatch threshold, spread_1d with a custom kernel must take
+        # the Pallas path and still match the pure-JAX reference.
+        from nufftax.core.spread import _PALLAS_MIN_M_SPREAD_1D
+
+        kernel = gaussian_kernel(NSPREAD, SIGMA)
+        (x,), c = _setup(max(_PALLAS_MIN_M_SPREAD_1D, 20_000), 1)
+        out = spread_1d(x, c, 256, kernel)
+        out_ref = spread_1d_impl(x, c, 256, kernel)
+        np.testing.assert_allclose(np.asarray(out), np.asarray(out_ref), rtol=5e-4, atol=5e-5)

--- a/tests/test_nufft3.py
+++ b/tests/test_nufft3.py
@@ -8,11 +8,7 @@ import jax.numpy as jnp
 import numpy as np
 import pytest
 
-
-# Enable float64 for 3D Type 3 tests which need higher precision
-jax.config.update("jax_enable_x64", True)
-
-from nufftax import (  # noqa: E402
+from nufftax import (
     compute_type3_grid_size,
     compute_type3_grid_sizes_2d,
     compute_type3_grid_sizes_3d,
@@ -20,6 +16,11 @@ from nufftax import (  # noqa: E402
     nufft2d3,
     nufft3d3,
 )
+
+
+# float64 is enabled suite-wide in conftest.py; these tests rely on it for the
+# high-precision comparisons against FINUFFT.
+assert jax.config.jax_enable_x64
 
 
 def direct_nufft1d3(x, c, s, isign=1):

--- a/tests/test_pallas_3d.py
+++ b/tests/test_pallas_3d.py
@@ -64,10 +64,9 @@ class TestSpread3dPallas:
 class TestPublicDispatch:
     @gpu_only
     def test_spread_3d_uses_pallas(self):
-        from nufftax.core.spread import _PALLAS_MIN_M_SPREAD_3D, spread_3d
+        from nufftax.core.spread import spread_3d
 
-        M = max(_PALLAS_MIN_M_SPREAD_3D, 10_000)
-        x, y, z, c, kp = _setup_3d(M=M, nf1=32, nf2=32, nf3=32)
+        x, y, z, c, kp = _setup_3d(M=10_000, nf1=32, nf2=32, nf3=32)
         out = spread_3d(x, y, z, c, 32, 32, 32, kp)
         out_ref = spread_3d_impl(x, y, z, c, 32, 32, 32, kp)
         np.testing.assert_allclose(out, out_ref, rtol=5e-4, atol=5e-5)

--- a/tests/test_pallas_grad.py
+++ b/tests/test_pallas_grad.py
@@ -1,0 +1,90 @@
+"""GPU-only: reverse-mode gradients w.r.t. nonuniform positions, through Pallas.
+
+Covers the case raised on PR #11 — reverse-mode ``grad`` w.r.t. the nonuniform
+positions of a Type 1 transform (e.g. ``nufft2d1``) while the fused Pallas
+spreading backend is active. The old size-threshold dispatch never routed the
+small-M gradient tests through Pallas, so this path was previously untested.
+
+Skipped unless a GPU is present and the Pallas backend is enabled
+(``NUFFTAX_PALLAS_BACKEND``).
+"""
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+from nufftax import nufft2d1
+from nufftax.core.kernel import compute_kernel_params
+from nufftax.core.spread import _HAS_PALLAS_GPU, _USE_PALLAS_SPREAD, spread_2d
+
+
+pallas_gpu_only = pytest.mark.skipif(
+    not (_HAS_PALLAS_GPU and _USE_PALLAS_SPREAD),
+    reason="requires a GPU with the Pallas backend enabled (NUFFTAX_PALLAS_BACKEND)",
+)
+
+
+def _positions(M, seed):
+    k = jax.random.split(jax.random.PRNGKey(seed), 2)
+    x = jax.random.uniform(k[0], (M,), minval=-jnp.pi, maxval=jnp.pi).astype(jnp.float32)
+    y = jax.random.uniform(k[1], (M,), minval=-jnp.pi, maxval=jnp.pi).astype(jnp.float32)
+    return x, y
+
+
+@pallas_gpu_only
+def test_spread_2d_grad_xy_through_pallas_finite_diff():
+    # grad w.r.t. positions of spread_2d (Pallas forward + custom VJP) must run
+    # under jax.grad, stay finite, and match central finite differences.
+    # Real strengths/cotangent avoid the complex-cotangent convention ambiguity.
+    M, nf1, nf2 = 24, 48, 48
+    x, y = _positions(M, seed=0)
+    c = jax.random.normal(jax.random.PRNGKey(1), (M,)).astype(jnp.complex64)  # real values
+    g = jax.random.normal(jax.random.PRNGKey(2), (nf2, nf1)).astype(jnp.float32)
+    kp = compute_kernel_params(1e-6)
+
+    @jax.jit
+    def loss(x, y):
+        return jnp.sum(g * jnp.real(spread_2d(x, y, c, nf1, nf2, kp)))
+
+    gx, gy = jax.grad(loss, argnums=(0, 1))(x, y)  # runs the Pallas forward under AD
+    assert np.all(np.isfinite(np.asarray(gx)))
+    assert np.all(np.isfinite(np.asarray(gy)))
+
+    eps = 1e-3
+    xn, yn = np.asarray(x), np.asarray(y)
+    fdx = np.zeros(M)
+    fdy = np.zeros(M)
+    for j in range(M):
+        xp, xm = xn.copy(), xn.copy()
+        xp[j] += eps
+        xm[j] -= eps
+        fdx[j] = (float(loss(jnp.asarray(xp), y)) - float(loss(jnp.asarray(xm), y))) / (2 * eps)
+        yp, ym = yn.copy(), yn.copy()
+        yp[j] += eps
+        ym[j] -= eps
+        fdy[j] = (float(loss(x, jnp.asarray(yp))) - float(loss(x, jnp.asarray(ym)))) / (2 * eps)
+
+    np.testing.assert_allclose(np.asarray(gx), fdx, rtol=2e-2, atol=2e-2)
+    np.testing.assert_allclose(np.asarray(gy), fdy, rtol=2e-2, atol=2e-2)
+
+
+@pallas_gpu_only
+def test_nufft2d1_grad_xy_through_pallas_runs():
+    # The exact case from PR #11: reverse-mode grad w.r.t. positions of nufft2d1
+    # on GPU with Pallas active. Must not raise and must give finite, nonzero grads.
+    M, N1, N2 = 2000, 32, 32
+    x, y = _positions(M, seed=3)
+    c = (jax.random.normal(jax.random.PRNGKey(4), (M,)) + 1j * jax.random.normal(jax.random.PRNGKey(5), (M,))).astype(
+        jnp.complex64
+    )
+
+    def loss(x, y):
+        return jnp.sum(jnp.abs(nufft2d1(x, y, c, (N1, N2), eps=1e-6)) ** 2).real
+
+    gx, gy = jax.grad(loss, argnums=(0, 1))(x, y)
+
+    assert np.all(np.isfinite(np.asarray(gx)))
+    assert np.all(np.isfinite(np.asarray(gy)))
+    assert np.linalg.norm(np.asarray(gx)) > 0
+    assert np.linalg.norm(np.asarray(gy)) > 0

--- a/tests/test_pallas_interpret.py
+++ b/tests/test_pallas_interpret.py
@@ -1,0 +1,99 @@
+"""Pallas spreading kernels in interpret mode (CPU, no GPU needed).
+
+Run with ``NUFFTAX_PALLAS_INTERPRET=1`` (a dedicated CI step does). This
+exercises the Pallas kernel logic — fold/rescale, indexing, kernel weights,
+float32 casts, the dtype dispatch guard — without Triton or a GPU.
+
+Interpret mode does NOT emulate atomic accumulation for duplicate indices, so
+all tests here use collision-free points: x-coordinates spaced more than
+nspread grid cells apart, which makes every kernel footprint disjoint (the 2D/3D
+footprints are separable, so disjoint x-cells suffice).
+"""
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+from nufftax.core.kernel import Kernel, compute_kernel_params
+from nufftax.core.pallas_spread import INTERPRET, spread_1d_pallas, spread_2d_pallas, spread_3d_pallas
+from nufftax.core.spread import spread_1d, spread_1d_impl, spread_2d_impl, spread_3d_impl
+
+
+pytestmark = pytest.mark.skipif(not INTERPRET, reason="run with NUFFTAX_PALLAS_INTERPRET=1")
+
+KP = compute_kernel_params(1e-6)  # nspread = 8
+M = 24
+NF1 = 512  # large enough for M footprints spaced 2*nspread apart, away from wrap
+
+
+def _collision_free_x(rng):
+    # Grid cells 2*nspread apart -> footprints [i0, i0+nspread-1] are disjoint
+    # and never wrap (max cell well below NF1).
+    cells = 2 * KP.nspread * np.arange(M) + KP.nspread + rng.uniform(0.1, 0.9, M)
+    return jnp.asarray((cells / NF1) * 2.0 * np.pi - np.pi, dtype=jnp.float32)
+
+
+@pytest.fixture
+def rng():
+    return np.random.default_rng(0)
+
+
+@pytest.fixture
+def x(rng):
+    return _collision_free_x(rng)
+
+
+@pytest.fixture
+def c(rng):
+    return jnp.asarray(rng.standard_normal(M) + 1j * rng.standard_normal(M)).astype(jnp.complex64)
+
+
+def test_spread_1d_interpret_matches_impl(x, c):
+    out = spread_1d_pallas(x, c, NF1, KP)
+    ref = spread_1d_impl(x, c, NF1, KP)
+    np.testing.assert_allclose(np.asarray(out), np.asarray(ref), rtol=5e-4, atol=5e-5)
+
+
+def test_spread_2d_interpret_matches_impl(x, c, rng):
+    y = jnp.asarray(rng.uniform(-np.pi, np.pi, M), dtype=jnp.float32)
+    out = spread_2d_pallas(x, y, c, NF1, 32, KP)
+    ref = spread_2d_impl(x, y, c, NF1, 32, KP)
+    np.testing.assert_allclose(np.asarray(out), np.asarray(ref), rtol=5e-4, atol=5e-5)
+
+
+def test_spread_3d_interpret_matches_impl(x, c, rng):
+    y = jnp.asarray(rng.uniform(-np.pi, np.pi, M), dtype=jnp.float32)
+    z = jnp.asarray(rng.uniform(-np.pi, np.pi, M), dtype=jnp.float32)
+    out = spread_3d_pallas(x, y, z, c, NF1, 16, 16, KP)
+    ref = spread_3d_impl(x, y, z, c, NF1, 16, 16, KP)
+    np.testing.assert_allclose(np.asarray(out), np.asarray(ref), rtol=5e-4, atol=5e-5)
+
+
+def test_custom_kernel_interpret_matches_impl(x, c):
+    sigma = 1.5
+    kernel = Kernel(nspread=KP.nspread, phi=lambda zz: jnp.exp(-(zz * zz) / (2.0 * sigma * sigma)))
+    out = spread_1d_pallas(x, c, NF1, kernel)
+    ref = spread_1d_impl(x, c, NF1, kernel)
+    np.testing.assert_allclose(np.asarray(out), np.asarray(ref), rtol=5e-4, atol=5e-5)
+
+
+def test_dispatch_routes_32bit_to_pallas(x, c):
+    # With interpret enabled, the public spread_1d routes 32-bit inputs through
+    # the Pallas path; on collision-free points it must match pure JAX.
+    out = spread_1d(x, c, NF1, KP)
+    ref = spread_1d_impl(x, c, NF1, KP)
+    np.testing.assert_allclose(np.asarray(out), np.asarray(ref), rtol=5e-4, atol=5e-5)
+
+
+def test_dispatch_keeps_64bit_on_pure_jax(rng):
+    # Regression test for the x64 routing bug: 64-bit inputs must NOT go
+    # through the float32 Pallas kernels. With float64/complex128 inputs the
+    # public spread_1d must match the pure-JAX impl to ~1e-12; if it were
+    # routed through Pallas the float32 cast would cap accuracy around 1e-7.
+    assert jax.config.jax_enable_x64  # suite-wide via conftest
+    x64 = jnp.asarray(_collision_free_x(rng), dtype=jnp.float64)
+    c128 = jnp.asarray(rng.standard_normal(M) + 1j * rng.standard_normal(M)).astype(jnp.complex128)
+    out = spread_1d(x64, c128, NF1, KP)
+    ref = spread_1d_impl(x64, c128, NF1, KP)
+    np.testing.assert_allclose(np.asarray(out), np.asarray(ref), rtol=1e-12, atol=1e-12)

--- a/tests/test_upsampfac.py
+++ b/tests/test_upsampfac.py
@@ -1,0 +1,88 @@
+"""Tests for the ``upsampfac`` option on Type 1 / Type 2 transforms.
+
+Covers: scalar default, scalar 1.25 (works but less accurate with the generic
+kernel), and the ``(forward, backward)`` tuple form that sets the oversampling of
+the forward transform and its adjoint (used in reverse-mode AD) independently.
+"""
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+from numpy.testing import assert_allclose
+
+from nufftax import nufft1d1, nufft1d2, nufft2d1
+
+
+@pytest.fixture
+def rng():
+    return np.random.default_rng(0)
+
+
+def _dft_1d1(x, c, n):
+    k = np.arange(-(n // 2), (n + 1) // 2)
+    return np.exp(1j * np.outer(k, np.asarray(x))) @ np.asarray(c)
+
+
+def test_default_equals_explicit_2(rng):
+    M, N = 200, 64
+    x = jnp.asarray(rng.uniform(-np.pi, np.pi, M))
+    c = (jnp.asarray(rng.standard_normal(M)) + 1j * jnp.asarray(rng.standard_normal(M))).astype(jnp.complex64)
+    assert_allclose(np.asarray(nufft1d1(x, c, N)), np.asarray(nufft1d1(x, c, N, upsampfac=2.0)), rtol=1e-4, atol=1e-6)
+    y = jnp.asarray(rng.uniform(-np.pi, np.pi, M))
+    assert_allclose(
+        np.asarray(nufft2d1(x, y, c, (N, N))),
+        np.asarray(nufft2d1(x, y, c, (N, N), upsampfac=2.0)),
+        rtol=1e-4,
+        atol=1e-6,
+    )
+
+
+def test_forward_accuracy_vs_upsampfac(rng):
+    M, N = 300, 64
+    x = jnp.asarray(rng.uniform(-np.pi, np.pi, M))
+    c = (jnp.asarray(rng.standard_normal(M)) + 1j * jnp.asarray(rng.standard_normal(M))).astype(jnp.complex64)
+    ref = _dft_1d1(x, c, N)
+
+    def relerr(uf):
+        f = np.asarray(nufft1d1(x, c, N, eps=1e-6, upsampfac=uf))
+        return np.max(np.abs(f - ref)) / np.max(np.abs(ref))
+
+    err2, err125 = relerr(2.0), relerr(1.25)
+    assert err2 < 1e-4
+    assert err125 < 1e-2  # the knob works; the generic kernel is just less accurate at 1.25
+    assert err125 > err2
+
+
+def test_tuple_forward_uses_first_element(rng):
+    M, N = 200, 64
+    x = jnp.asarray(rng.uniform(-np.pi, np.pi, M))
+    c = (jnp.asarray(rng.standard_normal(M)) + 1j * jnp.asarray(rng.standard_normal(M))).astype(jnp.complex64)
+    a = nufft1d1(x, c, N, upsampfac=(2.0, 1.25))  # forward uses 2.0
+    b = nufft1d1(x, c, N, upsampfac=2.0)
+    assert_allclose(np.asarray(a), np.asarray(b), rtol=1e-4, atol=1e-6)
+
+
+def test_grad_default_matches_explicit_and_tuple_runs(rng):
+    M, N = 100, 64
+    x = jnp.asarray(rng.uniform(-np.pi, np.pi, M))
+    c = (jnp.asarray(rng.standard_normal(M)) + 1j * jnp.asarray(rng.standard_normal(M))).astype(jnp.complex64)
+
+    def loss(c, uf):
+        return jnp.sum(jnp.abs(nufft1d1(x, c, N, upsampfac=uf)) ** 2).real
+
+    g_scalar = jax.grad(loss)(c, 2.0)
+    g_default = jax.grad(lambda c: jnp.sum(jnp.abs(nufft1d1(x, c, N)) ** 2).real)(c)
+    assert_allclose(np.asarray(g_scalar), np.asarray(g_default), rtol=1e-5, atol=1e-5)
+
+    g_tuple = jax.grad(loss)(c, (2.0, 1.25))  # adjoint at a different upsampfac
+    assert np.all(np.isfinite(np.asarray(g_tuple)))
+
+
+def test_type2_upsampfac_forward_and_grad(rng):
+    M, N = 200, 64
+    x = jnp.asarray(rng.uniform(-np.pi, np.pi, M))
+    f = (jnp.asarray(rng.standard_normal(N)) + 1j * jnp.asarray(rng.standard_normal(N))).astype(jnp.complex64)
+    assert_allclose(np.asarray(nufft1d2(x, f, upsampfac=2.0)), np.asarray(nufft1d2(x, f)), rtol=1e-4, atol=1e-6)
+    g = jax.grad(lambda f: jnp.sum(jnp.abs(nufft1d2(x, f, upsampfac=(2.0, 1.25))) ** 2).real)(f)
+    assert np.all(np.isfinite(np.asarray(g)))


### PR DESCRIPTION
Closes #10.

Exposes `spread_*` / `interp_*` for use with a user-supplied kernel instead of the built-in ES kernel — e.g. spreading short-range Gaussians without the full NUFFT pipeline.

**API**
- New `Kernel(nspread, phi, phi_and_dphi=None)` — `phi` is the kernel value, `phi_and_dphi` its optional analytic derivative (autodiff fallback otherwise, used for gradients w.r.t. coordinates).
- `spread_*` / `interp_*` now accept either `KernelParams` (ES, unchanged) or a `Kernel`.

**GPU**
Custom kernels run through the same fused Pallas kernels — `phi` is threaded into the Triton kernel as a static closure. The ES path takes the `phi=None` branch, byte-identical to before.