### PR TITLE
fix: replace removed batching.not_mapped with None for JAX 0.10.x compatibility

### DIFF
--- a/nufftax/transforms/primitives.py
+++ b/nufftax/transforms/primitives.py
@@ -36,12 +36,12 @@ def _make_batcher(prim, impl_fn, source_idx):
     """
 
     def batcher(args, dims, **kwargs):
-        batched = [i for i, d in enumerate(dims) if d is not batching.not_mapped]
+        batched = [i for i, d in enumerate(dims) if d is not None]
         # Fast path: only the source batched at axis 0
         if batched == [source_idx] and dims[source_idx] == 0:
             return prim.bind(*args, **kwargs), 0
         # Generic fallback: vmap-trace through the impl
-        in_axes = tuple(d if d is not batching.not_mapped else None for d in dims)
+        in_axes = tuple(d for d in dims)
         out = jax.vmap(lambda *a: impl_fn(*a, **kwargs), in_axes=in_axes)(*args)
         return out, 0
 


### PR DESCRIPTION
JAX 0.10 removed `jax.interpreters.batching.not_mapped` (the 'not batched' sentinel in batching rules, now simply `None`). The `_make_batcher` function in `primitives.py` still referenced the removed attribute, raising `AttributeError` on JAX >= 0.10.

Replace `batching.not_mapped` with `None` in the batching rule generator, matching the new JAX batching convention.